### PR TITLE
fix issue #8

### DIFF
--- a/src/main/java/de/unibi/cebitec/bibigrid/ctrl/CreateIntent.java
+++ b/src/main/java/de/unibi/cebitec/bibigrid/ctrl/CreateIntent.java
@@ -24,7 +24,7 @@ public class CreateIntent extends Intent {
     public List<String> getRequiredOptions(MODE mode) {
         switch (mode) {
             case AWS:
-                return Arrays.asList(new String[]{"m", "M", "s", "S", "n", "u", "k", "i", "e", "a", "z", "g", "r", "b"});
+                return Arrays.asList(new String[]{"m", "M", "s", "S", "n",  "k", "i", "e", "a", "z", "g", "r", "b"});
             case OPENSTACK:
                 return Arrays.asList(new String[]{"m", "M", "s", "S", "n",  "k", "i", "e", "z", "g", "r", "b", "osu", "ost", "osp", "ose"});
         }

--- a/src/main/java/de/unibi/cebitec/bibigrid/meta/openstack/ListIntentOpenstack.java
+++ b/src/main/java/de/unibi/cebitec/bibigrid/meta/openstack/ListIntentOpenstack.java
@@ -5,14 +5,9 @@
  */
 package de.unibi.cebitec.bibigrid.meta.openstack;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
 import de.unibi.cebitec.bibigrid.meta.ListIntent;
 import de.unibi.cebitec.bibigrid.model.Configuration;
 import de.unibi.cebitec.bibigrid.model.CurrentClusters;
-import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
-
-import org.jclouds.sshj.config.SshjSshClientModule;
 import static de.unibi.cebitec.bibigrid.ctrl.ListIntent.log;
 
 /**
@@ -27,9 +22,9 @@ public class ListIntentOpenstack extends OpenStackIntent implements ListIntent {
 
     @Override
     public boolean list() {
-        Iterable<Module> modules = ImmutableSet.<Module>of(
-                new SshjSshClientModule(),
-                new SLF4JLoggingModule());
+//        Iterable<Module> modules = ImmutableSet.<Module>of(
+//                new SshjSshClientModule(),
+//                new SLF4JLoggingModule());
         CurrentClusters cc = new CurrentClusters(os, conf);
         log.info(cc.printClusterList());
         return true;

--- a/src/main/java/de/unibi/cebitec/bibigrid/model/Cluster.java
+++ b/src/main/java/de/unibi/cebitec/bibigrid/model/Cluster.java
@@ -21,7 +21,7 @@ public class Cluster {
     private String vpc;
     private String securitygroup;
     private String keyname;
-    private String user = "unknown";
+    private String user;
     
     private String started = "unknown";
 

--- a/src/main/java/de/unibi/cebitec/bibigrid/model/CurrentClusters.java
+++ b/src/main/java/de/unibi/cebitec/bibigrid/model/CurrentClusters.java
@@ -102,7 +102,7 @@ public class CurrentClusters {
 
                     // user - should be always the same for all instances of one cluser
                     if (user != null) {
-                        if (cluster.getUser().equalsIgnoreCase("unknown")) {
+                        if (cluster.getUser() == null) {
                             cluster.setUser(user);
                         } else {
                             if (!cluster.getUser().equals(user)) {
@@ -202,8 +202,11 @@ public class CurrentClusters {
     }
 
     /**
+     * Determine cluster properties running OpenStack
+     * 
      *
      * @param os OpenStack
+     * @param conf
      */
     public CurrentClusters(OSClient os, Configuration conf) {
         String keypairName = conf.getKeypair();
@@ -218,7 +221,7 @@ public class CurrentClusters {
         for (Server serv : os.compute().servers().list()) {
             // check if instance is a BiBiGrid instance and extract clusterid from it
             String name = serv.getName();
-            
+            Map<String,String> metadata = serv.getMetadata(); 
    
             
             if (name != null && (name.startsWith("bibigrid-master-") || name.startsWith("bibigrid-slave-"))) {
@@ -229,9 +232,13 @@ public class CurrentClusters {
                     cluster = clustermap.get(clusterid);
                 } else {
                     cluster = new Cluster();
-                    cluster.setUser(serv.getMetadata().getOrDefault("user", "unknown"));
                     clustermap.put(clusterid, cluster);
                 }
+                // get user from metadata map 
+                if (cluster.getUser() == null) {
+                    cluster.setUser(metadata.get("user"));
+                }
+                               
                 // master / slave
                 if (name.contains("master")) {
                     cluster.setMasterinstance(serv.getId());


### PR DESCRIPTION
- use {os.user} as username if not set explicitly
- fix bug concerning correct username output when list running clusters