### PR TITLE
Fix: router_interface_distributed support in getRouterbyNetwork

### DIFF
--- a/src/main/java/de/unibi/cebitec/bibigrid/meta/openstack/CreateClusterEnvironmentOpenstack.java
+++ b/src/main/java/de/unibi/cebitec/bibigrid/meta/openstack/CreateClusterEnvironmentOpenstack.java
@@ -452,6 +452,10 @@ public class CreateClusterEnvironmentOpenstack
           plopt.deviceOwner("network:ha_router_replicated_interface");
           lop = ps.list(plopt);
         }
+        if (lop.isEmpty()) { // if no port found 3nd check for "network:router_interface_distributed"
+            plopt.deviceOwner("network:router_interface_distributed");
+            lop = ps.list(plopt);
+        }
          
         if (subnet == null && lop.size() > 1) {
             LOG.warn("Network (ID: {}) uses more than one router, return the 1st one !", network.getId());


### PR DESCRIPTION
When provisioning a cluster I get the following error:
```
...
WARN : No router matches given constraints ...
...
Ok : Master (ID: 4c96e2ec-96e8-429f-a2e3-77fec50474f2) started
Ok : addrlist null
...
Ok : addrlist null
Ok : addrlist [NovaAddress{address=10.2.2.12, type=fixed, version=4, macaddr=fa:16:3e:4c:fb:87, 
}]
ERROR: null [CreateClusterOpenstack:469]
java.lang.NullPointerException: null
        at de.unibi.cebitec.bibigrid.meta.openstack.CreateClusterOpenstack.getFloatingIP(CreateClusterOpenstack.java:634) ~[BiBiGrid-1.1.jar:na]
        at de.unibi.cebitec.bibigrid.meta.openstack.CreateClusterOpenstack.launchClusterInstances(CreateClusterOpenstack.java:289) ~[BiBiGrid-1.1.jar:na]
        at de.unibi.cebitec.bibigrid.ctrl.CreateIntent.startClusterAtSelectedCloudProvider(CreateIntent.java:75) [BiBiGrid-1.1.jar:na]
        at de.unibi.cebitec.bibigrid.ctrl.CreateIntent.execute(CreateIntent.java:40) [BiBiGrid-1.1.jar:na]
        at de.unibi.cebitec.bibigrid.StartUp.main(StartUp.java:127) [BiBiGrid-1.1.jar:na]
ERROR: Aborting operation. Instances already running. I will try to shut them down but in case of an error they might remain running. Please check manually afterwards. [CreateIntent:41]
```

The `router` field of `CreateClusterOpenStack.environment` is null.

In our case the fix was to additionally search for the device owner `network:router_interface_distributed` in `getRouterByNetwork`.

We run OpenStack Newton (de.NBI Cloud HD).

I am not sure about the search order of owners. I now put the `network:router_interface_destributed` behind the `network:ha_router_replicated_interface` to preserve the original search order.