### PR TITLE
fix(bibigridperf): remove padding when parsing hdparm output

### DIFF
--- a/bibigrid-core/src/main/resources/playbook/roles/common/files/bibigridperf.py
+++ b/bibigrid-core/src/main/resources/playbook/roles/common/files/bibigridperf.py
@@ -40,8 +40,8 @@ print('Average write speed of %.2f MB/sec over %s passes' % (write_speed, passes
 read_speed = 0.0
 for i in range(0, passes):
     read_speed_text = execute_cmd(['hdparm', '-t', '/dev/vda1'])
-    read_speed_text = read_speed_text.split(' = ')[1]
-    read_speed_text = read_speed_text.split(' ')[0]
+    read_speed_text = read_speed_text.split(' =')[1]
+    read_speed_text = read_speed_text.strip().split(' ')[0]
     read_speed += float(read_speed_text)
 read_speed = read_speed / passes
 print('Average read speed of %.2f MB/sec over %s passes' % (read_speed, passes))


### PR DESCRIPTION
`bibigridperf.py` seems to crash when the read speed reported by `hdparm` is so low that it is padded with more than one space in its output resulting in `read_speed += float('')`.

Before patch:
```
32173 MiB Memory
14 CPU cores with 1 threads and 2593.904 MHz
Average write speed of 147.00 MB/sec over 3 passes
Traceback (most recent call last):
  File "/usr/local/bin/bibigridperf", line 45, in <module>
    read_speed += float(read_speed_text)
ValueError: could not convert string to float: 
```

Example output of hdparm (consider the two spaces of padding in front of 79.37 that mess up the parsing):
```
/dev/vda1:
 Timing buffered disk reads: 246 MB in  3.10 seconds =  79.37 MB/sec
```

After patch:
```
32173 MiB Memory
14 CPU cores with 1 threads and 2593.904 MHz
Average write speed of 177.00 MB/sec over 3 passes
Average read speed of 25.58 MB/sec over 3 passes

```

