### PR TITLE
[FeatureRequest] Add available memory to slurm config

### DIFF
--- a/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
+++ b/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
@@ -6,11 +6,11 @@ SlurmUser=slurm
 
 # NODE CONFIGURATIONS
 {% if use_master_as_compute %}
-NodeName={{ master.hostname }} SocketsPerBoard={{ master.cores }} CoresPerSocket=1
+NodeName={{ master.hostname }} SocketsPerBoard={{ master.cores }} CoresPerSocket=1 RealMemory={{ master.memory }}
 {% endif %}
 {% set sl = [] %}
 {% for slave in slaves %}
-NodeName={{ slave.hostname }} SocketsPerBoard={{ slave.cores }} CoresPerSocket=1{{ sl.append(slave.hostname)}}
+NodeName={{ slave.hostname }} SocketsPerBoard={{ slave.cores }} CoresPerSocket=1 RealMemory={{ slave.memory }}{{ sl.append(slave.hostname)}} 
 {% endfor %}
 
 # PARTITION CONFIGURATIONS


### PR DESCRIPTION
By adding the available memory to the config file, it would be possible to control jobs by --mem.

This suggested change is not enough though, as memory is not part of the vars files at the moment. I don't know how complicated it is to add...