### PR TITLE
fix host group name for custom ansible roles

### DIFF
--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/Validator.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/Validator.java
@@ -125,9 +125,9 @@ public abstract class Validator {
                 LOG.error("Ansible: hosts parameter not set.");
                 return false;
             } else if (!role.getHosts().equals("master") &&
-                    !role.getHosts().equals("slave") &&
+                    !role.getHosts().equals("slaves") &&
                     !role.getHosts().equals("all")) {
-                LOG.error("Ansible: hosts parameter has to be defined either as 'master', 'slave' or 'all'.");
+                LOG.error("Ansible: hosts parameter has to be defined either as 'master', 'slaves' or 'all'.");
                 return false;
             }
         }


### PR DESCRIPTION
The configuration validator requires singular
https://github.com/BiBiServ/bibigrid/blob/2c6559b1279a6f15233eca0b5dae447e741537c4/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/Validator.java#L127-L130
while the cluster setup routine only checks for plural
https://github.com/BiBiServ/bibigrid/blob/2c6559b1279a6f15233eca0b5dae447e741537c4/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/intents/CreateCluster.java#L341-L351.