### PR TITLE
fix custom ansible role tar file extraction for multiple roles

### DIFF
--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
@@ -135,8 +135,8 @@ public final class ShellScriptCreator {
 
         // Extract ansible roles from files (.tar.gz, .tgz)
         script.append("cd ~/" + AnsibleResources.ROLES_ROOT_PATH + "\n");
-        script.append("tar -xzf *.tgz\n");
-        script.append("tar -xzf *.tar.gz\n");
+        script.append("for f in *.tgz; do tar -xzf $f; done\n");
+        script.append("for f in *.tar.gz; do tar -xzf $f; done\n");
         script.append("rm -rf *.tgz\n");
         script.append("rm -rf *.tar.gz\n");
         script.append("cd ~\n");


### PR DESCRIPTION
The tar file extraction of multiple roles results in a silent error because `tar` is unable to extract multiple files at once:
https://github.com/BiBiServ/bibigrid/blob/a44126a526e2a4cdfdf5a80e0acdf2addbca131a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java#L138-L139
Instead, it interprets additional command line arguments as path specifications to be extracted from the archive:
```
$ ls
another_example_role.tar.gz  example_role.tar.gz
$ tar -xzf *.tar.gz
tar: example_role.tar.gz: Nicht im Archiv gefunden.
tar: Beende mit Fehlerstatus aufgrund vorheriger Fehler
```
This pull request extracts the tar archives in a loop instead.