### PR TITLE
Bind mount ephemeral disks to prevent filesystem corruption after reboot

### DIFF
--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
@@ -49,9 +49,6 @@ public final class ShellScriptCreator {
         // configure SSH Config
         userData.append("log \"configure ssh\"\n");
         appendSshConfiguration(config, userData, keypair);
-        // umount possibly mounted ephemeral
-        userData.append("log \"umount possibly mounted ephemeral\"\n");
-        userData.append("umount /mnt\n");
         // finished
         userData.append("log \"userdata.finished\"\n");
         userData.append("exit 0\n");

--- a/bibigrid-core/src/main/resources/playbook/roles/master/tasks/005-disk.yml
+++ b/bibigrid-core/src/main/resources/playbook/roles/master/tasks/005-disk.yml
@@ -1,9 +1,9 @@
-# we have to make sure that the disk is NOT mounted by cloud-init beforehand
-- name: mount ephemeral disk
+- name: Create /vol bind mount from /mnt ephemeral
   mount:
     path: /vol
-    src: "{{ master.ephemerals[0] }}"
-    fstype: ext4
+    src: /mnt
+    fstype: none
+    opts: bind,auto
     state: mounted
   when: master.ephemerals[0] is defined
 

--- a/bibigrid-core/src/main/resources/playbook/roles/worker/tasks/005-disk.yml
+++ b/bibigrid-core/src/main/resources/playbook/roles/worker/tasks/005-disk.yml
@@ -1,14 +1,14 @@
-# we have to make sure that the disk is NOT mounted by cloud-init beforehand
-- name: mount disk
+- name: Create /vol/scratch bind mount from /mnt ephemeral
   mount:
     path: /vol/scratch
-    src: "{{ ephemerals[0] }}"
-    fstype: ext4
+    src: /mnt
+    fstype: none
+    opts: bind,auto
     state: mounted
   when:
     - ephemerals
     
-- name: Change permission for newly mounted /vol/scratch mount point
+- name: Change permissions for /vol/scratch mount point
   file:
     path: /vol/scratch
     state: directory


### PR DESCRIPTION
BiBiGrid prevents cloud-init from mounting the ephemeral disk on workers on first boot and mounts it to `/vol/scratch/` instead.
But both mount points end up inside `/etc/fstab` resulting in a double mount after reboot and subsequent filesystem corruption.

The same applies to the master instance with `/vol/`.

The proposed solution is a _bind mount_ instead of a re-mount ([mount(8)](http://man7.org/linux/man-pages/man8/mount.8.html)).