### PR TITLE
make Slurm workers return to service automatically after reboot

### DIFF
--- a/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
+++ b/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
@@ -59,4 +59,4 @@ SlurmdPidFile=/var/run/slurm-llnl/slurmd.pid
 FastSchedule=2
 
 # ERROR RECOVERY
-ReturnToService=1
+ReturnToService=2


### PR DESCRIPTION
Cloud instances might be rebooted for any reason (e.g. maintenance, power supply tests).
It currently requires manual intervention by the user to reactivate BiBiGrid Slurm worker nodes after reboots. This pull request removes the need for manual intervention.

From the [manual](https://slurm.schedmd.com/slurm.conf.html):
![DeepinBildschirmfoto_Bereich auswählen_20190829093457](https://user-images.githubusercontent.com/578509/63920140-7586d880-ca40-11e9-92cd-2ac421c625a0.png)