### PR TITLE
Add ansible role subfolder/#230

### DIFF
--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/intents/CreateCluster.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/intents/CreateCluster.java
@@ -469,6 +469,7 @@ public abstract class CreateCluster extends Intent {
                     Map<String, Object> additionalVars = yaml.load(vars);
                     roleVars.putAll(additionalVars);
                 }
+                // Written in site.yml, has to be 'vars/ROLE_NAME'
                 String roleVarsFile = "";
                 if (roleVars != null && !roleVars.isEmpty()) {
                     roleVarsFile = AnsibleResources.VARS_PATH + roleName + "-vars.yml";
@@ -525,9 +526,14 @@ public abstract class CreateCluster extends Intent {
                         customWorkerRoles.put(roleName, roleVarsFile);
                 }
             }
-            AnsibleConfig.writeHostsFile(channel, config.getSshUser(), workerInstances);
-
             String channel_dir = channel.getHome() + "/";
+
+            // Write custom site file
+            String site_file = channel_dir + AnsibleResources.SITE_CONFIG_FILE;
+            AnsibleConfig.writeSiteFile(channel.put(site_file),
+                    customMasterRoles, customWorkerRoles);
+
+            AnsibleConfig.writeHostsFile(channel, config.getSshUser(), workerInstances);
 
             // files for common configuration
             String login_file = channel_dir + AnsibleResources.COMMONS_LOGIN_FILE;
@@ -548,11 +554,6 @@ public abstract class CreateCluster extends Intent {
             // TODO network should be written in instance configuration when initializing
             // security group und server group
             AnsibleConfig.writeWorkerSpecificationFile(specification_stream, config, environment);
-
-            // Write custom site file
-            String site_file = channel_dir + AnsibleResources.SITE_CONFIG_FILE;
-            AnsibleConfig.writeSiteFile(channel.put(site_file),
-                     customMasterRoles, customWorkerRoles);
 
             // Write requirements file for ansible-galaxy support
             if (!ansibleGalaxyRoles.isEmpty()) {

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/AnsibleConfig.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/AnsibleConfig.java
@@ -76,6 +76,7 @@ public final class AnsibleConfig {
         List<String> common_vars =
                 Arrays.asList(AnsibleResources.LOGIN_YML, AnsibleResources.INSTANCES_YML, AnsibleResources.CONFIG_YML);
         String DEFAULT_IP_FILE = AnsibleResources.VARS_PATH + "{{ ansible_default_ipv4.address }}.yml";
+
         // master configuration
         Map<String, Object> master = new LinkedHashMap<>();
         master.put("hosts", "master");
@@ -90,8 +91,11 @@ public final class AnsibleConfig {
         List<String> roles = new ArrayList<>();
         roles.add("common");
         roles.add("master");
-        roles.addAll(customMasterRoles.keySet());
+        for (String master_role : customMasterRoles.keySet()) {
+            roles.add("{ role: 'additional/" + master_role + "', tags: '" + master_role + "' }");
+        }
         master.put("roles", roles);
+
         // worker configuration
         Map<String, Object> workers = new LinkedHashMap<>();
         workers.put("hosts", "workers");
@@ -108,6 +112,9 @@ public final class AnsibleConfig {
         roles.add("common");
         roles.add("worker");
         roles.addAll(customWorkerRoles.keySet());
+        for (String worker_role : customWorkerRoles.keySet()) {
+            roles.add("{ role: 'additional/" + worker_role + "', tags: '" + worker_role + "' }");
+        }
         workers.put("roles", roles);
         writeToOutputStream(stream, Arrays.asList(master, workers));
     }

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/AnsibleConfig.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/AnsibleConfig.java
@@ -91,11 +91,10 @@ public final class AnsibleConfig {
         List<String> roles = new ArrayList<>();
         roles.add("common");
         roles.add("master");
-        for (String master_role : customMasterRoles.keySet()) {
-            roles.add("{ role: 'additional/" + master_role + "', tags: '" + master_role + "' }");
+        for (String role_name : customMasterRoles.keySet()) {
+            roles.add("additional/" + role_name);
         }
         master.put("roles", roles);
-
         // worker configuration
         Map<String, Object> workers = new LinkedHashMap<>();
         workers.put("hosts", "workers");
@@ -111,9 +110,8 @@ public final class AnsibleConfig {
         roles = new ArrayList<>();
         roles.add("common");
         roles.add("worker");
-        roles.addAll(customWorkerRoles.keySet());
-        for (String worker_role : customWorkerRoles.keySet()) {
-            roles.add("{ role: 'additional/" + worker_role + "', tags: '" + worker_role + "' }");
+        for (String role_name : customWorkerRoles.keySet()) {
+            roles.add("additional/" + role_name);
         }
         workers.put("roles", roles);
         writeToOutputStream(stream, Arrays.asList(master, workers));
@@ -130,7 +128,7 @@ public final class AnsibleConfig {
     }
 
     /**
-     * Generates roles/requirements.yml automatically including roles to install via ansible-galaxy.
+     * Generates roles/additional/requirements.yml automatically including roles to install via ansible-galaxy.
      * @param stream write file to remote
      */
     public static void writeRequirementsFile(OutputStream stream, List<Configuration.AnsibleGalaxyRoles> galaxyRoles) {

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/Configuration.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/model/Configuration.java
@@ -239,7 +239,7 @@ public abstract class Configuration {
         this.masterInstance = masterInstance;
         if (masterInstance != null) {
             StringBuilder display = new StringBuilder();
-            display.append("[type=").append(masterInstance.getType()).append(", image=")
+            display.append("\n[type=").append(masterInstance.getType()).append(", image=")
                     .append(masterInstance.getImage()).append("] ");
             LOG.info(V, "Master instance configuration set: {}", display);
         }
@@ -267,9 +267,9 @@ public abstract class Configuration {
         if (workerInstances != null && !workerInstances.isEmpty()) {
             StringBuilder display = new StringBuilder();
             for (WorkerInstanceConfiguration instanceConfiguration : workerInstances) {
-                display.append("[type=").append(instanceConfiguration.getType())
+                display.append("\n[type=").append(instanceConfiguration.getType())
                         .append(", image=").append(instanceConfiguration.getImage())
-                        .append(", count=").append(instanceConfiguration.getCount()).append("] ");
+                        .append(", count=").append(instanceConfiguration.getCount()).append("]");
             }
             LOG.info(V, "Worker instance(s) configuration set: {}", display);
         }

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
@@ -32,8 +32,6 @@ public final class AnsibleResources {
     public static final String INSTANCES_YML = VARS_PATH + "instances.yml";
     public static final String CONFIG_YML = VARS_PATH + "common_configuration.yml";
     public static final String WORKER_SPECIFICATION_YML = VARS_PATH + "worker_specification.yml";
-    public static final String SITE_YML = "site.yml";
-    public static final String REQUIREMENTS_YML = "requirements.yml";
     public static final String HOSTS_CONFIG_FILE = ROOT_PATH + ANSIBLE_HOSTS;
     public static final String ADDITIONAL_ROLES_PATH = "additional/";
     public static final String CONFIG_ROOT_PATH = ROOT_PATH + VARS_PATH;
@@ -45,8 +43,6 @@ public final class AnsibleResources {
     public static final String ADDITIONAL_ROLES_ROOT_PATH = ROLES_ROOT_PATH + ADDITIONAL_ROLES_PATH;
 
     // Full files
-    public static final String HOSTS_CONFIG_FILE = ROOT_PATH + ANSIBLE_HOSTS;
-    public static final String COMMONS_CONFIG_FILE = CONFIG_ROOT_PATH + COMMON_YML;
     public static final String SITE_CONFIG_FILE = ROOT_PATH + SITE_YML;
     public static final String REQUIREMENTS_CONFIG_FILE = ROOT_PATH + REQUIREMENTS_YML;
     private final List<String> files = new ArrayList<>();

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
@@ -1,5 +1,7 @@
 package de.unibi.cebitec.bibigrid.core.util;
 
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,6 +81,7 @@ public final class AnsibleResources {
         File directory = new File(url.getPath());
         File[] directoryFiles = directory.listFiles();
         if (directoryFiles == null) {
+            LoggerFactory.getLogger(AnsibleResources.class).warn("Ansible Resources, dir: " + directory.getName());
             return;
         }
         for (File file : directoryFiles) {

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
@@ -33,15 +33,18 @@ public final class AnsibleResources {
     public static final String SITE_YML = "site.yml";
     public static final String REQUIREMENTS_YML = "requirements.yml";
     public static final String HOSTS_CONFIG_FILE = ROOT_PATH + ANSIBLE_HOSTS;
+    public static final String ADDITIONAL_ROLES_PATH = "additional/";
     public static final String CONFIG_ROOT_PATH = ROOT_PATH + VARS_PATH;
     public static final String ROLES_ROOT_PATH = ROOT_PATH + ROLES_PATH;
     public static final String COMMONS_LOGIN_FILE = ROOT_PATH + LOGIN_YML;
     public static final String COMMONS_INSTANCES_FILE = ROOT_PATH + INSTANCES_YML;
     public static final String COMMONS_CONFIG_FILE = ROOT_PATH + CONFIG_YML;
     public static final String WORKER_SPECIFICATION_FILE = ROOT_PATH + WORKER_SPECIFICATION_YML;
+    public static final String ADDITIONAL_ROLES_ROOT_PATH = ROLES_ROOT_PATH + ADDITIONAL_ROLES_PATH;
 
     // Full files
-    public static final String COMMONS_CONFIG_FILE = ROOT_PATH + VARS_PATH + COMMON_YML;
+    public static final String HOSTS_CONFIG_FILE = ROOT_PATH + ANSIBLE_HOSTS;
+    public static final String COMMONS_CONFIG_FILE = CONFIG_ROOT_PATH + COMMON_YML;
     public static final String SITE_CONFIG_FILE = ROOT_PATH + SITE_YML;
     public static final String REQUIREMENTS_CONFIG_FILE = ROOT_PATH + REQUIREMENTS_YML;
     private final List<String> files = new ArrayList<>();

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
@@ -15,9 +15,15 @@ import java.util.jar.JarFile;
  * @author mfriedrichs(at)techfak.uni-bielefeld.de
  */
 public final class AnsibleResources {
+    // File names
+    public static final String ANSIBLE_HOSTS = "ansible_hosts";
+    public static final String COMMON_YML = "common.yml";
+    public static final String SITE_YML = "site.yml";
+    public static final String REQUIREMENTS_YML = "requirements.yml";
+
+    // Paths
     public static final String UPLOAD_PATH = "/tmp/roles/";
     public static final String ROOT_PATH = "playbook/";
-    public static final String ANSIBLE_HOSTS = "ansible_hosts";
     public static final String VARS_PATH = "vars/";
     public static final String ROLES_PATH = "roles/";
     public static final String LOGIN_YML = VARS_PATH + "login.yml";
@@ -33,6 +39,9 @@ public final class AnsibleResources {
     public static final String COMMONS_INSTANCES_FILE = ROOT_PATH + INSTANCES_YML;
     public static final String COMMONS_CONFIG_FILE = ROOT_PATH + CONFIG_YML;
     public static final String WORKER_SPECIFICATION_FILE = ROOT_PATH + WORKER_SPECIFICATION_YML;
+
+    // Full files
+    public static final String COMMONS_CONFIG_FILE = ROOT_PATH + VARS_PATH + COMMON_YML;
     public static final String SITE_CONFIG_FILE = ROOT_PATH + SITE_YML;
     public static final String REQUIREMENTS_CONFIG_FILE = ROOT_PATH + REQUIREMENTS_YML;
     private final List<String> files = new ArrayList<>();

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/AnsibleResources.java
@@ -44,7 +44,7 @@ public final class AnsibleResources {
 
     // Full files
     public static final String SITE_CONFIG_FILE = ROOT_PATH + SITE_YML;
-    public static final String REQUIREMENTS_CONFIG_FILE = ROOT_PATH + REQUIREMENTS_YML;
+    public static final String REQUIREMENTS_CONFIG_FILE = ADDITIONAL_ROLES_ROOT_PATH + REQUIREMENTS_YML;
     private final List<String> files = new ArrayList<>();
 
     public AnsibleResources() {

--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/util/ShellScriptCreator.java
@@ -152,11 +152,11 @@ public final class ShellScriptCreator {
         // Run ansible-galaxy to install ansible-galaxy roles from galaxy, git or url (.tar.gz)
         if (config.hasCustomAnsibleGalaxyRoles()) {
             script.append("ansible-galaxy install --roles-path ~/"
-                    + AnsibleResources.ROLES_ROOT_PATH
+                    + AnsibleResources.ADDITIONAL_ROLES_ROOT_PATH
                     + " -r ~/" + AnsibleResources.REQUIREMENTS_CONFIG_FILE + "\n");
         }
         // Extract ansible roles from files (.tar.gz, .tgz)
-        script.append("cd ~/" + AnsibleResources.ROLES_ROOT_PATH + "\n");
+        script.append("cd ~/" + AnsibleResources.ADDITIONAL_ROLES_ROOT_PATH + "\n");
         script.append("for f in $(find /tmp/roles -type f -regex '.*\\.t\\(ar\\.\\)?gz'); do tar -xzf $f; done\n");
         script.append("cd ~\n");
 

--- a/bibigrid-core/src/main/resources/playbook/roles/additional/example/meta/main.yml
+++ b/bibigrid-core/src/main/resources/playbook/roles/additional/example/meta/main.yml
@@ -1,0 +1,28 @@
+galaxy_info:
+  role_name: Hello-World Example
+  author: Tim Dilger
+  description: Shows working example of installing Ansible Role.
+  company: Bielefeld university, CeBiTec, BiBiServ
+
+  license: BSD
+
+  min_ansible_version: 2.7
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+    - name: Debian
+      versions:
+        - stretch
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+
+  galaxy_tags:
+    - hello-world
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/bibigrid-core/src/main/resources/playbook/roles/additional/example/tasks/main.yml
+++ b/bibigrid-core/src/main/resources/playbook/roles/additional/example/tasks/main.yml
@@ -1,0 +1,3 @@
+- debug:
+    msg: 
+    - "Hello {{ ansible_user }}!"

--- a/bibigrid-openstack/src/main/java/de/unibi/cebitec/bibigrid/openstack/CreateClusterOpenstack.java
+++ b/bibigrid-openstack/src/main/java/de/unibi/cebitec/bibigrid/openstack/CreateClusterOpenstack.java
@@ -434,7 +434,6 @@ public class CreateClusterOpenstack extends CreateCluster {
             if (addressList == null) {
                 LOG.info(V,"Waiting for address ...");
             }
-
         } while (addressList == null || addressList.isEmpty());
         LOG.info(V, "address: {}", addressList);
         return addressList.get(0);


### PR DESCRIPTION
Ansible roles uploaded or downloaded from ansible galaxy have been placed in 'playbook/roles/' together with common, master and worker.
For a better overview and in case additional roles are called 'master', 'worker' or 'common', they are now placed in 'playbook/roles/additional/'.