### PR TITLE
changed slurm consumable resources config

### DIFF
--- a/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
+++ b/bibigrid-core/src/main/resources/playbook/roles/common/templates/slurm/slurm.conf
@@ -29,6 +29,10 @@ ClusterName=bibigrid
 SlurmctldPort=6817
 SlurmdPort=6818
 
+#Set slurm consumable resources
+SelectType=select/cons_res
+SelectTypeParameters=CR_Core
+
 # DIRECTORIES
 JobCheckpointDir=/var/lib/slurm-llnl/job_checkpoint
 SlurmdSpoolDir=/var/lib/slurm-llnl/slurmd


### PR DESCRIPTION
This PR fixes the problem that slurm can only use one job per node.
For example with the current version if a cluster with slurm is started with two workers a 4 cores:

sleep.sh:
> !#/bin/bash
sleep 90

> squeue
            JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                29     debug sleep.sh   ubuntu PD       0:00      1 (Resources)
                30     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                31     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                32     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                33     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                34     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                35     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                36     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                37     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                38     debug sleep.sh   ubuntu PD       0:00      1 (Priority)
                27     debug sleep.sh   ubuntu  R       0:01      1 bibigrid-worker-1-2-chfugwdsrlqbc7csr
                28     debug sleep.sh   ubuntu  R       0:01      1 bibigrid-worker-1-1-chfugwdsrlqbc7csr

Every job needs the whole worker.

With this Changes it is using all cores (tested with 2 workers a 2 cores):

![Clipboard - 30  Juli 2020 14_15](https://user-images.githubusercontent.com/29981967/88925667-1dbaa800-d275-11ea-8582-4e3965620094.png)

