### PR TITLE
fix(BibigridInfoIdGetHandler):just added a space to avoid confusion

### DIFF
--- a/bibigrid-light-rest-4j/src/main/java/de/unibi/cebitec/bibigrid/light_rest_4j/handler/BibigridInfoIdGetHandler.java
+++ b/bibigrid-light-rest-4j/src/main/java/de/unibi/cebitec/bibigrid/light_rest_4j/handler/BibigridInfoIdGetHandler.java
@@ -27,7 +27,7 @@ public class BibigridInfoIdGetHandler implements LightHttpHandler {
             String clusterId = exchange.getQueryParameters().get("id").getFirst();
             Status status = DataBase.getDataBase().status.get(clusterId);
             if (status == null) {
-                status = new Status(Status.CODE.Error, "Unknown cluster id" + clusterId + "!");
+                status = new Status(Status.CODE.Error, "Unknown cluster id " + clusterId + "!");
             }
             exchange.getResponseHeaders().add(new HttpString("Content-Type"), "application/json");
             exchange.setStatusCode(200);


### PR DESCRIPTION
Example: "msg":"Unknown cluster idoqmxzrxfrme3yje!"  to - > "msg":"Unknown cluster id oqmxzrxfrme3yje!"