### PR TITLE
add ipRange values to example config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,10 @@ workerInstances:
 ports:
   - type: TCP
     number: 80
+    ipRange: current
   - type: TCP
     number: 443
+    ipRange: current
 
 nfs: yes
 slurm: yes


### PR DESCRIPTION
When using the example configuration from the README, it looks like the internally used value (`current`) for the `ipRange` of a port is somehow passed to the Neutron API which is unsurprisingly unable to handle it:

```
Ok : Using existing subnet. (ID: 1cfe9e28-0c6b-4aa5-936e-a1e1429d08e7, CIDR: 192.168.10.0/24)
ERROR: Failed to create cluster. current is not a valid IP network. {} [StartUp:298]
de.unibi.cebitec.bibigrid.core.model.exceptions.ConfigurationException: current is not a valid IP network.
	at de.unibi.cebitec.bibigrid.openstack.CreateClusterEnvironmentOpenstack.createSecurityGroup(CreateClusterEnvironmentOpenstack.java:187)
	at de.unibi.cebitec.bibigrid.openstack.CreateClusterEnvironmentOpenstack.createSecurityGroup(CreateClusterEnvironmentOpenstack.java:40)
	at de.unibi.cebitec.bibigrid.StartUp.runCreateIntent(StartUp.java:278)
	at de.unibi.cebitec.bibigrid.StartUp.runIntent(StartUp.java:164)
	at de.unibi.cebitec.bibigrid.StartUp.main(StartUp.java:89)
Caused by: org.openstack4j.api.exceptions.ClientResponseException: current is not a valid IP network.
	at org.openstack4j.core.transport.HttpExceptionHandler.mapException(HttpExceptionHandler.java:38)
	at org.openstack4j.core.transport.HttpExceptionHandler.mapException(HttpExceptionHandler.java:23)
	at org.openstack4j.core.transport.HttpEntityHandler.handleLessThan500(HttpEntityHandler.java:101)
	at org.openstack4j.core.transport.HttpEntityHandler.handle(HttpEntityHandler.java:47)
	at org.openstack4j.connectors.resteasy.HttpResponseImpl.getEntity(HttpResponseImpl.java:64)
	at org.openstack4j.openstack.internal.BaseOpenStackService$Invocation.execute(BaseOpenStackService.java:225)
	at org.openstack4j.openstack.internal.BaseOpenStackService$Invocation.execute(BaseOpenStackService.java:207)
	at org.openstack4j.openstack.compute.internal.ComputeSecurityGroupServiceImpl.createRule(ComputeSecurityGroupServiceImpl.java:89)
	at de.unibi.cebitec.bibigrid.openstack.CreateClusterEnvironmentOpenstack.createSecurityGroup(CreateClusterEnvironmentOpenstack.java:183)
	... 4 common frames omitted
ERROR: Cluster setup was interrupted!
```

By adding `ipRange: current` explicitly to each of the ports I was able to circumvent this error and create a cluster.