### PR TITLE
fix(cluster-scaling): Added cluster initialization when adding worker instances

### DIFF
--- a/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/intents/CreateCluster.java
+++ b/bibigrid-core/src/main/java/de/unibi/cebitec/bibigrid/core/intents/CreateCluster.java
@@ -232,6 +232,13 @@ public abstract class CreateCluster extends Intent {
             io.printStackTrace();
             return false;
         }
+
+        if (cluster.getMasterInstance() == null) {
+            LoadClusterConfigurationIntent loadIntent = providerModule.getLoadClusterConfigurationIntent(config);
+            loadIntent.loadClusterConfiguration(cluster.getClusterId());
+            cluster = loadIntent.getCluster(cluster.getClusterId());
+        }
+        
         Session sshSession = null;
         boolean success = true;
         try {


### PR DESCRIPTION
Hi,

after encountering the same problem as stated in issue #325, it was found that the `cluster` field of the `CreateCluster` intent was not fully initialized.

In the context of the `ScaleWorkerIntent` only the cluster id is set in the constructor, which -in my case - led to
```
Exception in thread "main" java.lang.NullPointerException
        at de.unibi.cebitec.bibigrid.core.intents.CreateCluster.createWorkerInstances(CreateCluster.java:238)
        at de.unibi.cebitec.bibigrid.StartUp.runIntent(StartUp.java:226)
        at de.unibi.cebitec.bibigrid.StartUp.main(StartUp.java:89)
```

The fix proposed in this PR aims at providing a fully initialized instance for the `cluster` field, to enable any subsequent calls on this instance, e.g. `cluster.getMasterInstance()` for SSH port check.

However the ansible setup, after the VM instances where successfully created, did not complete, but I'm not sure this is related to the changes in this PR. I can open an issue for this error of course.

```
    Ok : TASK [common : Disable auto-update/upgrade during ansible-run] *****************
    Ok : changed: [192.168.0.109]
    Ok : changed: [192.168.0.192]
    Ok : TASK [common : Update] *********************************************************
    Ok : changed: [192.168.0.192]
    Ok : changed: [192.168.0.109]
    Ok : TASK [common : Install common packages] ****************************************
    Ok : fatal: [192.168.0.109]: FAILED! => {"changed": false, "msg": "No package matching 'python3-pip' is available"}
    Ok : fatal: [192.168.0.192]: FAILED! => {"changed": false, "msg": "No package matching 'python3-pip' is available"}
    Ok : PLAY RECAP *********************************************************************
    Ok : 192.168.0.109              : ok=5    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
    Ok : 192.168.0.192              : ok=5    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
    WARN : /usr/lib/python3.8/subprocess.py:848: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
    WARN :   self.stdout = io.open(c2pread, 'rb', bufsize)
    WARN : /usr/lib/python3.8/subprocess.py:853: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
    WARN :   self.stderr = io.open(errread, 'rb', bufsize)
    Ok : CONFIGURATION FAILED
    ERROR: Update may not be finished properly due to a configuration error. [CreateCluster:327]
    ERROR: Could not create 2 worker instances with specified batch 1. [StartUp:228]
```