### PR TITLE
Rescue when cid is master name

### DIFF
--- a/bibigrid/core/startup.py
+++ b/bibigrid/core/startup.py
@@ -38,7 +38,7 @@ def get_cluster_id_from_mem():
     return None
 
 
-def set_logger(verbosity):
+def set_logger_verbosity(verbosity):
     """
     Sets verbosity, format and handler.
     :param verbosity: level of verbosity
@@ -48,7 +48,6 @@ def set_logger(verbosity):
     capped_verbosity = min(verbosity, len(VERBOSITY_LIST) - 1)
     # LOG.basicConfig(format=LOGGER_FORMAT, level=VERBOSITY_LIST[capped_verbosity],
     #                    handlers=LOGGING_HANDLER_LIST)
-    logging.basicConfig(format=LOGGER_FORMAT, handlers=LOGGING_HANDLER_LIST)
 
     log = logging.getLogger("bibigrid")
     log.setLevel(VERBOSITY_LIST[capped_verbosity])
@@ -126,9 +125,9 @@ def main():
     Interprets command line, sets logger, reads configuration and runs selected action. Then exits.
     :return:
     """
-
+    logging.basicConfig(format=LOGGER_FORMAT, handlers=LOGGING_HANDLER_LIST)
     args = command_line_interpreter.interpret_command_line()
-    set_logger(args.verbose)
+    set_logger_verbosity(args.verbose)
     configurations = configuration_handler.read_configuration(args.config_input)
     if configurations:
         sys.exit(run_action(args, configurations, args.config_input))

--- a/bibigrid/core/utility/command_line_interpreter.py
+++ b/bibigrid/core/utility/command_line_interpreter.py
@@ -3,10 +3,25 @@ Has necessary methods and variables to interpret the command line
 """
 
 import argparse
+import logging
 import os
 
 STANDARD_CONFIG_INPUT_PATH = os.path.expanduser("~/.config/bibigrid")
 FOLDER_START = ("~/", "/")
+LOG = logging.getLogger("bibigrid")
+
+
+def check_cid(cid):
+    if "-" in cid:
+        new_cid = cid.split("-")[-1]
+        LOG.info("-cid %s is not a cid, but probably the entire master name. Using '%s' as "
+                    "cid instead.", cid, new_cid)
+        return new_cid
+    elif "." in cid:
+        LOG.info("-cid %s is not a cid, but probably the master's ip. "
+                    "Using the master ip instead of cid only works if a cluster key is in your systems default ssh key "
+                    "location (~/.ssh/). Otherwise bibigrid can't identify the cluster key.")
+    return cid
 
 
 def interpret_command_line():
@@ -24,7 +39,7 @@ def interpret_command_line():
                                                                        "Relative paths can be used and start "
                                                                        "at ~/.config/bibigrid", required=True,
                         type=lambda s: s if s.startswith(FOLDER_START) else os.path.join(STANDARD_CONFIG_INPUT_PATH, s))
-    parser.add_argument("-cid", "--cluster_id", metavar="<cluster-id>", type=str, default="",
+    parser.add_argument("-cid", "--cluster_id", metavar="<cluster-id>", type=check_cid, default="",
                         help="Cluster id is needed for ide and termination")
 
     actions = parser.add_mutually_exclusive_group(required=True)


### PR DESCRIPTION
If a master name instead of a cid is entered as a -cid, bibigrid will use the cid instead and log the process as info. If a master ip instead of a cid is entered, this will be logged in info now, too. Closes #354 