### PR TITLE
Fix program crash when image is not active

### DIFF
--- a/bibigrid/core/utility/validate_configuration.py
+++ b/bibigrid/core/utility/validate_configuration.py
@@ -282,7 +282,7 @@ class ValidateConfiguration:
         if instance_image["status"] != "active":
             LOG.warning("Instance %s image: %s not active", instance_name, instance_image_id_or_name)
             print("Available active images:")
-            print("\n".join(provider.get_active_images))
+            print("\n".join(provider.get_active_images()))
             return False
         LOG.info("Instance %s image: %s found", instance_name, instance_image_id_or_name)
         instance_type = instance["type"]

--- a/resources/playbook/roles/bibigrid/tasks/020-disk-worker.yml
+++ b/resources/playbook/roles/bibigrid/tasks/020-disk-worker.yml
@@ -1,14 +1,14 @@
 - when: "'ephemeral' in group_names"
   block:
-  - name: Mount ephemeral
-    mount:
-      path: /vol/scratch
-      src: /mnt
-      fstype: none
-      opts: bind,auto
-      state: mounted
-  - name: Set 0777 rights for ephemeral mount
-    file:
-      path: /vol/scratch
-      state: directory
-      mode: 0777
+    - name: Mount ephemeral
+      mount:
+        path: /vol/scratch
+        src: /mnt
+        fstype: none
+        opts: bind,auto
+        state: mounted
+    - name: Set 0777 rights for ephemeral mount
+      file:
+        path: /vol/scratch
+        state: directory
+        mode: 0777


### PR DESCRIPTION
Instead of calling a function and iterate over the returned value BiBiGrid tried to iterate over the function itself as `()` was missing. Now it prints active images as expected.