### PR TITLE
Improve Command Line Interface

### DIFF
--- a/bibigrid/core/actions/version.py
+++ b/bibigrid/core/actions/version.py
@@ -17,9 +17,9 @@ GIT_HUB = "https://github.com/BiBiServ/bibigrid"
 
 
 def version():
-    print(f"BiBiGrid {__version__} ({RELEASE_DATE})\nUniversität Bielefeld\nWebsite: {GIT_HUB}\n\n"
+    print(f"BiBiGrid {__version__} ({RELEASE_DATE})\nBielefeld University\n{GIT_HUB}\n\n"
           "# Configuration Folders\n")
     for directory in configuration_handler.CLOUDS_YAML_PATHS:
         if os.path.isdir(os.path.expanduser(directory)):
             print(f"## '{directory}'\n")
-            seedir.seedir(directory)
+            seedir.seedir(directory, exclude_folders=["keys"])

--- a/bibigrid/core/actions/version.py
+++ b/bibigrid/core/actions/version.py
@@ -3,4 +3,23 @@ Contains the static variable __version__ which holds the current version number.
 https://www.akeeba.com/how-do-version-numbers-work.html
 """
 
+import logging
+import os
+import seedir
+
+from bibigrid.core.utility.handler import configuration_handler
+
+LOG = logging.getLogger("bibigrid")
+
 __version__ = "0.3.0"
+RELEASE_DATE = "2023"
+GIT_HUB = "https://github.com/BiBiServ/bibigrid"
+
+
+def version():
+    print(f"BiBiGrid {__version__} ({RELEASE_DATE})\nUniversität Bielefeld\nWebsite: {GIT_HUB}\n\n"
+          "# Configuration Folders\n")
+    for directory in configuration_handler.CLOUDS_YAML_PATHS:
+        if os.path.isdir(os.path.expanduser(directory)):
+            print(f"## '{directory}'\n")
+            seedir.seedir(directory)

--- a/bibigrid/core/utility/command_line_interpreter.py
+++ b/bibigrid/core/utility/command_line_interpreter.py
@@ -6,7 +6,8 @@ import argparse
 import logging
 import os
 
-STANDARD_CONFIG_INPUT_PATH = os.path.expanduser("~/.config/bibigrid")
+INPUT_PATH = "~/.config/bibigrid"
+STANDARD_CONFIG_INPUT_PATH = os.path.expanduser(INPUT_PATH)
 FOLDER_START = ("~/", "/")
 LOG = logging.getLogger("bibigrid")
 
@@ -15,12 +16,12 @@ def check_cid(cid):
     if "-" in cid:
         new_cid = cid.split("-")[-1]
         LOG.info("-cid %s is not a cid, but probably the entire master name. Using '%s' as "
-                    "cid instead.", cid, new_cid)
+                 "cid instead.", cid, new_cid)
         return new_cid
     if "." in cid:
         LOG.info("-cid %s is not a cid, but probably the master's ip. "
-                    "Using the master ip instead of cid only works if a cluster key is in your systems default ssh key "
-                    "location (~/.ssh/). Otherwise bibigrid can't identify the cluster key.")
+                 "Using the master ip instead of cid only works if a cluster key is in your systems default ssh key "
+                 "location (~/.ssh/). Otherwise bibigrid can't identify the cluster key.")
     return cid
 
 
@@ -29,21 +30,23 @@ def interpret_command_line():
     Interprets commandline. Used in startup.py
     :return:
     """
-    parser = argparse.ArgumentParser(description='Bibigrid sets up cluster easily inside a cloud environment')
+    parser = argparse.ArgumentParser(description='BiBiGrid easily sets up clusters within a cloud environment')
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increases logging verbosity. `-v` adds more info to the logfile, "
-                             "`-vv` adds debug information to the logfile.")
-    parser.add_argument("-d", "--debug", action='store_true', help="Keeps cluster active. Asks before shutdown. "
-                                                                   "Offers termination after create")
+                             "`-vv` adds debug information to the logfile")
+    parser.add_argument("-d", "--debug", action='store_true', help="Keeps cluster active even when crashing. "
+                                                                   "Asks before shutdown. "
+                                                                   "Offers termination after successful create")
     parser.add_argument("-i", "--config_input", metavar="<path>", help="Path to YAML configurations file. "
                                                                        "Relative paths can be used and start "
-                                                                       "at ~/.config/bibigrid", required=True,
+                                                                       f"at '{INPUT_PATH}'. "
+                                                                       "Required for all actions but '--version'",
                         type=lambda s: s if s.startswith(FOLDER_START) else os.path.join(STANDARD_CONFIG_INPUT_PATH, s))
     parser.add_argument("-cid", "--cluster_id", metavar="<cluster-id>", type=check_cid, default="",
-                        help="Cluster id is needed for ide and termination")
-
+                        help="Cluster id is needed for '--ide', '--terminate_cluster' and '--update'. "
+                             "If not set, last created cluster's id is used")
     actions = parser.add_mutually_exclusive_group(required=True)
-    actions.add_argument("-V", "--version", action='store_true', help="Displays version")
+    actions.add_argument("-V", "--version", action='store_true', help="Displays installed BiBiGrid version and info.")
     actions.add_argument("-t", "--terminate_cluster", action='store_true',
                          help="Terminates cluster. Needs cluster-id set.")
     actions.add_argument("-c", "--create", action='store_true', help="Creates cluster")
@@ -51,9 +54,12 @@ def interpret_command_line():
                          help="Lists all running clusters. If cluster-id is set, will list this cluster in detail only")
     actions.add_argument("-ch", "--check", action='store_true', help="Validates cluster configuration")
     actions.add_argument("-ide", "--ide", action='store_true',
-                         help="Establishes a secured connection to ide. Needs cluster-id set")
+                         help="Establishes a secure connection to ide. Needs cluster-id set")
     actions.add_argument("-u", "--update", action='store_true', help="Updates master's playbook. "
-                                                                     "Needs cluster-id set, no job running "
+                                                                     "Needs cluster-id set, no jobs running "
                                                                      "and no workers up")
     args = parser.parse_args()
+    needs_config = args.terminate_cluster or args.create or args.list_clusters or args.check or args.ide
+    if needs_config and not args.config_input:
+        parser.error("requested action requires '-i' ('--config_input')")
     return args

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-openstackclient==6.0.0
 PyYAML
 shortuuid
 sshtunnel
+seedir


### PR DESCRIPTION
In the past one had to pass a configuration file even to check the version number. That was a residuum from the old bibigrid that implemented the CLI that way.
It's quite tricky to implement a "conditional required argument" in python, but the solution used now is throwing a command line parsing error whenever an action is executed that requires a configuration but none is given. That way configuration is no longer required, but when used with an action that actually requires it.

Also the version message has been improved containing the release date, some general information and a list of files within the configuration directory now.

This closes
#419 
#395