### PR TITLE
Auto image picker

### DIFF
--- a/bibigrid.yml
+++ b/bibigrid.yml
@@ -50,6 +50,8 @@
   #waitForServices:  # existing service name that runs after an instance is launched. BiBiGrid's playbook will wait until service is "stopped" to avoid issues
   #  - de.NBI_Bielefeld_environment.service  # uncomment for cloud site Bielefeld
 
+  # nearestImage: True # if true, the nearest fitting image will be picked if your image doesn't match exactly
+
   # master configuration
   masterInstance:
     type: # existing type/flavor on your cloud. See launch instance>flavor for options

--- a/bibigrid.yml
+++ b/bibigrid.yml
@@ -1,4 +1,5 @@
   # See https://cloud.denbi.de/wiki/Tutorials/BiBiGrid/ (after update)
+  # See https://github.com/BiBiServ/bibigrid/blob/master/documentation/markdown/features/configuration.md
   # First configuration also holds general cluster information and must include the master.
   # All other configurations mustn't include another master, but exactly one vpngtw instead (keys like master).
 
@@ -43,7 +44,7 @@
   #localDNSlookup: True
   #zabbix: True
   #nfs: True
-  #ide: True # Very useful to set on True. Use `./bibigrid.sh -i [path-to-bibigrid.yml] -ide -cid [cluster-id]` to start port forwarding to access the ide.
+  #ide: True # A nice way to view your cluster as if you were using Visual Studio Code
 
   useMasterAsCompute: True # Currently ignored by slurm
   
@@ -53,7 +54,7 @@
   # master configuration
   masterInstance:
     type: # existing type/flavor on your cloud. See launch instance>flavor for options
-    image: # existing image on your cloud. See https://openstack.cebitec.uni-bielefeld.de/project/images pick an active one. Currently only ubuntu22.04 is supported
+    image: # existing active image on your cloud. Consider using regex to prevent image updates from breaking your running cluster
     # features: # list
 
   # -- END: GENERAL CLUSTER INFORMATION --
@@ -63,7 +64,7 @@
   # worker configuration
   #workerInstances:
   #  - type: # existing type/flavor on your cloud. See launch instance>flavor for options
-  #    image: # same as master
+  #    image: # same as master. Consider using regex to prevent image updates from breaking your running cluster
   #    count: # any number of workers you would like to create with set type, image combination
   #    # features: # list
 

--- a/bibigrid.yml
+++ b/bibigrid.yml
@@ -50,8 +50,6 @@
   #waitForServices:  # existing service name that runs after an instance is launched. BiBiGrid's playbook will wait until service is "stopped" to avoid issues
   #  - de.NBI_Bielefeld_environment.service  # uncomment for cloud site Bielefeld
 
-  # nearestImage: True # if true, the nearest fitting image will be picked if your image doesn't match exactly
-
   # master configuration
   masterInstance:
     type: # existing type/flavor on your cloud. See launch instance>flavor for options
@@ -59,6 +57,8 @@
     # features: # list
 
   # -- END: GENERAL CLUSTER INFORMATION --
+
+  # fallbackOnOtherImage: False # if True, most similar image by name will be picked. A regex can also be given instead.
 
   # worker configuration
   #workerInstances:

--- a/bibigrid/core/utility/ansible_configurator.py
+++ b/bibigrid/core/utility/ansible_configurator.py
@@ -95,7 +95,8 @@ def write_host_and_group_vars(configurations, providers, cluster_id):  # pylint:
             worker_dict = {"name": name, "regexp": regexp, "image": worker["image"],
                            "network": configuration["network"], "flavor": flavor_dict,
                            "gateway_ip": configuration["private_v4"],
-                           "cloud_identifier": configuration["cloud_identifier"]}
+                           "cloud_identifier": configuration["cloud_identifier"],
+                           "fallback_on_other_image": configuration.get("fallbackOnOtherImage", False)}
 
             worker_features = worker.get("features", [])
             if isinstance(worker_features, str):
@@ -120,7 +121,8 @@ def write_host_and_group_vars(configurations, providers, cluster_id):  # pylint:
                            "flavor": flavor_dict,
                            "wireguard_ip": wireguard_ip,
                            "cloud_identifier": configuration[
-                               "cloud_identifier"]}
+                               "cloud_identifier"],
+                           "fallback_on_other_image": configuration.get("fallbackOnOtherImage", False)}
             if configuration.get("wireguard_peer"):
                 vpngtw_dict["wireguard"] = {"ip": wireguard_ip,
                                             "peer": configuration.get(
@@ -136,7 +138,8 @@ def write_host_and_group_vars(configurations, providers, cluster_id):  # pylint:
                            "floating_ip": configuration["floating_ip"], "flavor": flavor_dict,
                            "private_v4": configuration["private_v4"],
                            "cloud_identifier": configuration["cloud_identifier"],
-                           "volumes": configuration["volumes"]}
+                           "volumes": configuration["volumes"],
+                           "fallback_on_other_image": configuration.get("fallbackOnOtherImage", False)}
             if configuration.get("wireguard_peer"):
                 master_dict["wireguard"] = {"ip": "10.0.0.1", "peer": configuration.get("wireguard_peer")}
             write_yaml(os.path.join(aRP.GROUP_VARS_FOLDER, "master.yml"), master_dict)

--- a/bibigrid/core/utility/handler/ssh_handler.py
+++ b/bibigrid/core/utility/handler/ssh_handler.py
@@ -120,7 +120,7 @@ def is_active(client, floating_ip_address, private_key, username, timeout=5):
                 LOG.error(f"Attempt to connect to {floating_ip_address} failed.")
                 raise ConnectionException(exc) from exc
         except socket.timeout as exc:
-            LOG.warning("Socket timeout exception occurred. Try again ...")
+            LOG.info("Socket timeout exception occurred. Try again ...")
             if attempts < timeout:
                 attempts += 1
             else:

--- a/bibigrid/core/utility/image_selection.py
+++ b/bibigrid/core/utility/image_selection.py
@@ -1,0 +1,30 @@
+"""
+Methods for image selection
+"""
+import difflib
+import re
+
+from bibigrid.models.exceptions import ImageDeactivatedException
+
+
+def select_image(configuration, provider, image, log):
+    # check if image is active
+    active_images = provider.get_active_images()
+    if image not in active_images:
+        old_image = image
+        log.info(f"Image '{old_image}' has no direct match. Maybe it's a regex? Trying regex match.")
+        image = next((elem for elem in active_images if re.match(image, elem)), None)
+        if not image:
+            log.warning(f"Couldn't find image '{old_image}'.")
+            if isinstance(configuration.get("fallbackOnOtherImage"), str):
+                image = next(elem for elem in active_images if re.match(configuration["fallbackOnOtherImage"], elem))
+                log.info(f"Taking first regex ('{configuration['fallbackOnOtherImage']}') match '{image}'.")
+            elif configuration.get("fallbackOnOtherImage", False):
+                image = difflib.get_close_matches(old_image, active_images)[0]
+                log.info(f"Taking closest active image (in name) '{image}' instead.")
+            else:
+                raise ImageDeactivatedException(f"Image {old_image} no longer active or doesn't exist.")
+            log.info(f"Using alternative '{image}' instead of '{old_image}'. You should change the configuration.")
+        else:
+            log.info(f"Taking first regex match: '{image}'")
+    return image

--- a/bibigrid/models/exceptions.py
+++ b/bibigrid/models/exceptions.py
@@ -15,3 +15,11 @@ class ConfigurationException(Exception):
 
 class ConflictException(Exception):
     """ Conflict exception"""
+
+
+class ImageDeactivatedException(Exception):
+    """ Image deactivated exception"""
+
+
+class ImageNotFoundException(Exception):
+    """ Image not found exception"""

--- a/bibigrid/openstack/openstack_provider.py
+++ b/bibigrid/openstack/openstack_provider.py
@@ -15,7 +15,7 @@ from keystoneauth1.identity import v3
 from bibigrid.core import provider
 from bibigrid.core.actions import create
 from bibigrid.core.actions import version
-from bibigrid.models.exceptions import ExecutionException, ConflictException
+from bibigrid.models.exceptions import ExecutionException, ConflictException, ImageDeactivatedException
 
 LOG = logging.getLogger("bibigrid")
 
@@ -117,6 +117,8 @@ class OpenstackProvider(provider.Provider):  # pylint: disable=too-many-public-m
             server = self.conn.create_server(name=name, flavor=flavor, image=image, network=network, key_name=key_name,
                                              volumes=volumes, security_groups=security_groups)
         except openstack.exceptions.BadRequestException as exc:
+            if "is not active" in str(exc):
+                raise ImageDeactivatedException() from exc
             raise ConnectionError() from exc
         except openstack.exceptions.SDKException as exc:
             raise ExecutionException() from exc

--- a/documentation/markdown/features/configuration.md
+++ b/documentation/markdown/features/configuration.md
@@ -181,6 +181,16 @@ openstack image list --os-cloud=openstack | grep active
 
 Currently, images based on Ubuntu 20.04/22.04 (Focal/Jammy) and Debian 11(Bullseye) are supported.
 
+###### Using Regex
+Instead of using a specific image you can also provide a regex.
+For example if your images are named by following the pattern `Ubuntu 22.04 LTS ($DATE)` and on ly the 
+most recent release is active, you can use `Ubuntu 22.04 LTS \(.*\)` so it always picks the right one.
+
+This regex will also be used when starting worker instances on demand
+and is therefore mandatory to automatically resolve image updates of the described kind while running a cluster.
+
+There's also a [Fallback Option](#fallbackonotherimage-optional).
+
 ##### Find your active `type`s
 `flavor` is just the OpenStack terminology for `type`.
 
@@ -225,7 +235,7 @@ You can create features for the master [in the same way](#features-optional) as 
 ```yaml
   masterInstance:
     type: de.NBI tiny
-    image: Ubuntu 22.04 LTS (2022-10-14)
+    image: Ubuntu 22.04 LTS (2022-10-14) # regex allowed
     features:
       - hasdatabase
       - holdsinformation
@@ -238,8 +248,21 @@ Exactly one in every configuration but the first:
 ```yaml
   vpngtw:
     type: de.NBI tiny
-    image: Ubuntu 22.04 LTS (2022-10-14)
+    image: Ubuntu 22.04 LTS (2022-10-14) # regex allowed
 ```
+
+### fallbackOnOtherImage (optional)
+If set to `true` and an image is not among the active images, 
+BiBiGrid will try to pick a fallback image for you by finding the closest active image by name that has at least 60% name overlap.
+This will not find a good fallback every time.
+
+You can also set `fallbackOnOtherImage` to a regex like `Ubuntu 22.04 LTS \(.*\)` in which case BiBiGrid will pick an
+active image matching that regex.
+This can be combined with the regular regex option from the [image key](#find-your-active-images).
+In that case the fallback regex should be more open to be still useful when the original regex failed to find an active image.
+
+This fallback will also be used when starting worker instances on demand
+and can be helpful to when image updates occur while running a cluster.
 
 #### sshUser (required)
 

--- a/resources/playbook/roles/bibigrid/files/slurm/create_server.py
+++ b/resources/playbook/roles/bibigrid/files/slurm/create_server.py
@@ -49,11 +49,11 @@ def select_image(start_worker_group, connection):
         image = next((elem for elem in active_images if re.match(image, elem)), None)
         if not image:
             logging.warning(f"Couldn't find image '{old_image}'.")
-            if isinstance(start_worker_group.get("fallbackOnOtherImage"), str):
+            if isinstance(start_worker_group.get("fallback_on_other_image"), str):
                 image = next(
-                    elem for elem in active_images if re.match(start_worker_group["fallbackOnOtherImage"], elem))
-                logging.info(f"Taking first regex ('{start_worker_group['fallbackOnOtherImage']}') match '{image}'.")
-            elif start_worker_group.get("fallbackOnOtherImage", False):
+                    elem for elem in active_images if re.match(start_worker_group["fallback_on_other_image"], elem))
+                logging.info(f"Taking first regex ('{start_worker_group['fallback_on_other_image']}') match '{image}'.")
+            elif start_worker_group.get("fallback_on_other_image", False):
                 image = difflib.get_close_matches(old_image, active_images)[0]
                 logging.info(f"Taking closest active image (in name) '{image}' instead.")
             else:


### PR DESCRIPTION
1. Image definitions in the configuration can now be regexes:
```yaml
  masterInstance:
    type: de.NBI small
    image: Ubuntu 22\.04 LTS \(.*\)
```
2.  fallbackOnOtherImage takes either a bool value or a regex. If True is given, the nearest image by name is used if the original image (can be regex) is not found among the active images. If a regex is given, the first regex match is used instead when the original image (can be regex) is not found among the active images.
3. Added documentation for this feature.