### PR TITLE
Additional partitions

### DIFF
--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -101,14 +101,12 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             "useMasterWithPublicIp", True)
         self.log.debug("Keyname: %s", self.key_name)
 
-
     def create_defaults(self):
         if not self.configurations[0].get("customAnsibleCfg", False) or not os.path.isfile(a_rp.ANSIBLE_CFG_PATH):
             shutil.copy(a_rp.ANSIBLE_CFG_DEFAULT_PATH, a_rp.ANSIBLE_CFG_PATH)
         if not self.configurations[0].get("customSlurmConf", False) or not os.path.isfile(
                 a_rp.SLURM_CONF_TEMPLATE_PATH):
             shutil.copy(a_rp.SLURM_CONF_TEMPLATE_DEFAULT_PATH, a_rp.SLURM_CONF_TEMPLATE_PATH)
-
 
     def generate_keypair(self):
         """

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -59,13 +59,6 @@ DEFAULT_SECURITY_GROUP_NAME = "default" + SEPARATOR + "{cluster_id}"
 WIREGUARD_SECURITY_GROUP_NAME = "wireguard" + SEPARATOR + "{cluster_id}"
 
 
-def create_defaults():
-    if not os.path.isfile(a_rp.ANSIBLE_CFG_PATH):
-        shutil.copy(a_rp.ANSIBLE_CFG_DEFAULT_PATH, a_rp.ANSIBLE_CFG_PATH)
-    if not os.path.isfile(a_rp.SLURM_CONF_TEMPLATE_PATH):
-        shutil.copy(a_rp.SLURM_CONF_TEMPLATE_DEFAULT_PATH, a_rp.SLURM_CONF_TEMPLATE_PATH)
-
-
 class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
     """
     The class Create holds necessary methods to execute the Create-Action
@@ -107,6 +100,15 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         self.use_master_with_public_ip = not configurations[0].get("gateway") and configurations[0].get(
             "useMasterWithPublicIp", True)
         self.log.debug("Keyname: %s", self.key_name)
+
+
+    def create_defaults(self):
+        if not self.configurations[0].get("customAnsibleCfg", False) or not os.path.isfile(a_rp.ANSIBLE_CFG_PATH):
+            shutil.copy(a_rp.ANSIBLE_CFG_DEFAULT_PATH, a_rp.ANSIBLE_CFG_PATH)
+        if not self.configurations[0].get("customSlurmConf", False) or not os.path.isfile(
+                a_rp.SLURM_CONF_TEMPLATE_PATH):
+            shutil.copy(a_rp.SLURM_CONF_TEMPLATE_DEFAULT_PATH, a_rp.SLURM_CONF_TEMPLATE_PATH)
+
 
     def generate_keypair(self):
         """
@@ -422,7 +424,7 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         try:
             self.generate_keypair()
             self.prepare_configurations()
-            create_defaults()
+            self.create_defaults()
             self.generate_security_groups()
             self.start_start_server_threads()
             self.extended_network_configuration()

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -102,10 +102,13 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         self.log.debug("Keyname: %s", self.key_name)
 
     def create_defaults(self):
+        self.log.debug("Creating default files")
         if not self.configurations[0].get("customAnsibleCfg", False) or not os.path.isfile(a_rp.ANSIBLE_CFG_PATH):
+            self.log.debug("Copying ansible.cfg")
             shutil.copy(a_rp.ANSIBLE_CFG_DEFAULT_PATH, a_rp.ANSIBLE_CFG_PATH)
         if not self.configurations[0].get("customSlurmConf", False) or not os.path.isfile(
                 a_rp.SLURM_CONF_TEMPLATE_PATH):
+            self.log.debug("Copying slurm.conf")
             shutil.copy(a_rp.SLURM_CONF_TEMPLATE_DEFAULT_PATH, a_rp.SLURM_CONF_TEMPLATE_PATH)
 
     def generate_keypair(self):

--- a/bibigrid/core/utility/ansible_configurator.py
+++ b/bibigrid/core/utility/ansible_configurator.py
@@ -96,7 +96,8 @@ def write_host_and_group_vars(configurations, providers, cluster_id, log):  # py
                            "network": configuration["network"], "flavor": flavor_dict,
                            "gateway_ip": configuration["private_v4"],
                            "cloud_identifier": configuration["cloud_identifier"],
-                           "on_demand": worker.get("onDemand", True)}
+                           "on_demand": worker.get("onDemand", True),
+                           "partitions": worker.get("partitions", []) + ["all", configuration["cloud_identifier"]]}
 
             worker_features = worker.get("features", [])
             if isinstance(worker_features, str):
@@ -104,6 +105,7 @@ def write_host_and_group_vars(configurations, providers, cluster_id, log):  # py
             features = set(configuration_features + worker_features)
             if features:
                 worker_dict["features"] = features
+
             pass_through(configuration, worker_dict, "waitForServices", "wait_for_services")
             write_yaml(os.path.join(aRP.GROUP_VARS_FOLDER, group_name), worker_dict, log)
         vpngtw = configuration.get("vpnInstance")
@@ -135,7 +137,8 @@ def write_host_and_group_vars(configurations, providers, cluster_id, log):  # py
                            "flavor": flavor_dict, "private_v4": configuration["private_v4"],
                            "cloud_identifier": configuration["cloud_identifier"], "volumes": configuration["volumes"],
                            "fallback_on_other_image": configuration.get("fallbackOnOtherImage", False),
-                           "on_demand": False}
+                           "on_demand": False,
+                           "partitions": master.get("partitions", []) + ["all", configuration["cloud_identifier"]]}
             if configuration.get("wireguard_peer"):
                 master_dict["wireguard"] = {"ip": "10.0.0.1", "peer": configuration.get("wireguard_peer")}
             pass_through(configuration, master_dict, "waitForServices", "wait_for_services")

--- a/bibigrid/core/utility/ansible_configurator.py
+++ b/bibigrid/core/utility/ansible_configurator.py
@@ -64,6 +64,7 @@ def generate_site_file_yaml(user_roles):
                 host_dict["vars_files"] = host_dict["vars_files"] + user_role.get("varsFiles", [])
                 host_dict["roles"] = host_dict["roles"] + [{"role": role["name"], "tags": role.get("tags", [])} for role
                                                            in user_role["roles"]]
+
     return site_yaml
 
 
@@ -278,26 +279,6 @@ def get_cidrs(configurations):
                           "provider_cidrs": configuration["subnet_cidrs"]}
         all_cidrs.append(provider_cidrs)
     return all_cidrs
-
-
-def get_ansible_roles(ansible_roles, log):
-    """
-    Checks if ansible_roles have all necessary values and returns True if so.
-    @param ansible_roles: ansible_roles from master configuration (first configuration)
-    @param log:
-    @return: list of valid ansible_roles
-    """
-    ansible_roles_yaml = []
-    for ansible_role in (ansible_roles or []):
-        if ansible_role.get("file") and ansible_role.get("hosts"):
-            ansible_role_dict = {"file": ansible_role["file"], "hosts": ansible_role["hosts"]}
-            for key in ["name", "vars", "vars_file"]:
-                if ansible_role.get(key):
-                    ansible_role_dict[key] = ansible_role[key]
-            ansible_roles_yaml.append(ansible_role_dict)
-        else:
-            log.warning("Ansible role %s had neither galaxy,git nor url. Not added.", ansible_role)
-    return ansible_roles_yaml
 
 
 def get_ansible_galaxy_roles(ansible_galaxy_roles, log):

--- a/resources/defaults/ansible/ansible.cfg
+++ b/resources/defaults/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 # This file is moved programmatically to /etc/ansible/ansible.cfg on the master so it shouldn't be moved manually
 [defaults]
-roles_path = "/opt/playbook/roles:/opt/playbook/roles_galaxy:/opt/playbook/roles_user"
+roles_path = /opt/playbook/roles:/opt/playbook/roles_galaxy:/opt/playbook/roles_user
 inventory = ./ansible_hosts
 host_key_checking = False
 forks=50

--- a/resources/defaults/slurm/slurm.j2
+++ b/resources/defaults/slurm/slurm.j2
@@ -64,25 +64,31 @@ SlurmdDebug=info
 SlurmdLogFile=/var/log/slurm/slurmd.log
 
 # COMPUTE NODES
-{% set sl = {} %}
-{% set all = {"nodes":[]} %}
+{% set partitions = {} %}
+{% set exclude_groups = [] %}
 {% set master_or_empty = groups.master if use_master_as_compute else [] %}
-{% for node_name in master_or_empty +groups.workers %}
+{% set node_groups = [] %}
+{% for node_name in master_or_empty + groups.workers %}
 {% set node = hostvars[node_name] %}
-{% set mem = node.flavor.ram // 1024 * 1000 %}
-{% if node.cloud_identifier not in sl %}
-{{ sl.update({node.cloud_identifier: []}) }}
+{% if node.name not in node_groups %}
+{% if not node.on_demand %}
+{% set _ = exclude_groups.append(node.name) %}
 {% endif %}
-{% if node.name not in sl[node.cloud_identifier] %}
-NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=1 RealMemory={{ mem - [mem // 2, 16000] | min }} State={{'CLOUD' if node.on_demand else 'UNKNOWN'}} {{"Features="+node.features|join(",") if node.features is defined}}# {{ node.cloud_identifier }}
-{{ sl[node.cloud_identifier].append(node.name)}}
-{{ all.nodes.append(node.name)}}
+{% set _ = node_groups.append(node.name) %}
+{% set mem = (node.flavor.ram // 1024) * 1000 %}
+NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=1 RealMemory={{ mem - [mem // 2, 16000] | min }} State={{ 'CLOUD' if node.on_demand else 'UNKNOWN' }} {{"Features=" + (node.features | join(",")) if node.features is defined }}# {{ node.cloud_identifier }}
+{% for partition in node.partitions %}
+{% if partition not in partitions %}
+{% set _ = partitions.update({partition: []}) %}
+{% endif %}
+{% set _ = partitions[partition].append(node.name) %}
+{% endfor %}
 {% endif %}
 {% endfor %}
-{% for key,value in sl.items() %}
-PartitionName={{ key }} Nodes={{ value|join(",") }}
+
+{% for key, value in partitions.items() %}
+PartitionName={{ key }} Nodes={{ value | join(",") }}
 {% endfor %}
-PartitionName=All Nodes = {{ all.nodes|join(",") }} default=yes
 
 # JobSubmitPlugin
 JobSubmitPlugins=all_partitions
@@ -95,7 +101,7 @@ SuspendProgram=/opt/slurm/terminate.sh
 # Suspend time is 10 minutes (600 seconds)
 SuspendTime= {{ slurm_conf.elastic_scheduling.SuspendTime }}
 # Excludes {{ hostvars[groups.master.0].name }} from suspend
-SuspendExcNodes={{ hostvars[groups.master.0].name }}
+SuspendExcNodes={{ exclude_groups | join(',') }}
 # Maximum number of nodes
 TreeWidth= {{ slurm_conf.elastic_scheduling.TreeWidth }}
 # Do not cache dns names

--- a/tests/test_ansible_configurator.py
+++ b/tests/test_ansible_configurator.py
@@ -29,19 +29,69 @@ class TestAnsibleConfigurator(TestCase):
                       'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']}]
         self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml([]))
 
-    def test_generate_site_file_yaml_role(self):
-        custom_roles = [{"file": "file", "hosts": "hosts", "name": "name", "vars": "vars", "vars_file": "varsFile"}]
+    def test_generate_site_file_yaml_master_role(self):
+        user_roles = [{'hosts': ['master'], 'roles': [{'name': 'resistance_nextflow', 'tags': ['rn']}]}]
         # vars_files = ['vars/login.yml', 'vars/common_configuration.yml', 'varsFile']
         site_yaml = [{'become': 'yes', 'hosts': 'master',
-                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-master']}, 'additional/name'],
-                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'varsFile']},
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-master']},
+                                {'role': 'resistance_nextflow', 'tags': ['rn']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']},
                      {'become': 'yes', 'hosts': 'vpngtw',
-                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-vpngtw']}, 'additional/name'],
-                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'varsFile']},
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-vpngtw']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']},
                      {'become': 'yes', 'hosts': 'workers',
-                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-worker']}, 'additional/name'],
-                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'varsFile']}]
-        self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml(custom_roles))
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-worker']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']}]
+        self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml(user_roles))
+
+    def test_generate_site_file_yaml_vpngtw_role(self):
+        user_roles = [{'hosts': ['vpngtw'], 'roles': [{'name': 'resistance_nextflow'}], 'varsFiles': ['vars/rn']}]
+        # vars_files = ['vars/login.yml', 'vars/common_configuration.yml', 'varsFile']
+        site_yaml = [{'become': 'yes', 'hosts': 'master',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-master']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']},
+                     {'become': 'yes', 'hosts': 'vpngtw',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-vpngtw']},
+                                {'role': 'resistance_nextflow', 'tags': []}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'vars/rn']},
+                     {'become': 'yes', 'hosts': 'workers',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-worker']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']}]
+        self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml(user_roles))
+
+    def test_generate_site_file_yaml_workers_role(self):
+        user_roles = [{'hosts': ['workers'], 'roles': [{'name': 'resistance_nextflow'}]}]
+        # vars_files = ['vars/login.yml', 'vars/common_configuration.yml', 'varsFile']
+        site_yaml = [{'become': 'yes', 'hosts': 'master',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-master']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']},
+                     {'become': 'yes', 'hosts': 'vpngtw',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-vpngtw']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']},
+                     {'become': 'yes', 'hosts': 'workers',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-worker']},
+                                {'role': 'resistance_nextflow', 'tags': []}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml']}]
+        self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml(user_roles))
+
+    def test_generate_site_file_yaml_all_role(self):
+        user_roles = [
+            {'hosts': ['master', 'vpngtw', 'workers'], 'roles': [{'name': 'resistance_nextflow', 'tags': ['rn']}],
+             'varsFiles': ['vars/rn']}]
+        # vars_files = ['vars/login.yml', 'vars/common_configuration.yml', 'varsFile']
+        site_yaml = [{'become': 'yes', 'hosts': 'master',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-master']},
+                                {'role': 'resistance_nextflow', 'tags': ['rn']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'vars/rn']},
+                     {'become': 'yes', 'hosts': 'vpngtw',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-vpngtw']},
+                                {'role': 'resistance_nextflow', 'tags': ['rn']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'vars/rn']},
+                     {'become': 'yes', 'hosts': 'workers',
+                      'roles': [{'role': 'bibigrid', 'tags': ['bibigrid', 'bibigrid-worker']},
+                                {'role': 'resistance_nextflow', 'tags': ['rn']}],
+                      'vars_files': ['vars/common_configuration.yml', 'vars/hosts.yml', 'vars/rn']}]
+        self.assertEqual(site_yaml, ansible_configurator.generate_site_file_yaml(user_roles))
 
     def test_generate_common_configuration_false(self):
         cidrs = "42"
@@ -173,7 +223,6 @@ class TestAnsibleConfigurator(TestCase):
                                                                                                  default_user,
                                                                                                  startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
-        print(generated_common_configuration)
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
     def test_generate_common_configuration_ide(self):
@@ -201,32 +250,6 @@ class TestAnsibleConfigurator(TestCase):
                                                                                                  startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
-
-    def test_generate_common_configuration_ansible_roles_mock(self):
-        cidrs = "42"
-        ansible_roles = [{elem: elem for elem in ["file", "hosts", "name", "vars", "vars_file"]}]
-        cluster_id = "21"
-        default_user = "ubuntu"
-        ssh_user = "test"
-        configuration = [{"ansibleRoles": ansible_roles}]
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
-        self.assertEqual(ansible_roles, generated_common_configuration["ansible_roles"])
-
-    def test_generate_common_configuration_ansible_galaxy_roles(self):
-        cidrs = "42"
-        cluster_id = "21"
-        default_user = "ubuntu"
-        ssh_user = "test"
-        galaxy_roles = [{elem: elem for elem in ["hosts", "name", "galaxy", "git", "url", "vars", "vars_file"]}]
-        configuration = [{"ansibleGalaxyRoles": galaxy_roles}]
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
-        self.assertEqual(galaxy_roles, generated_common_configuration["ansible_galaxy_roles"])
 
     @patch("bibigrid.core.utility.ansible_configurator.to_instance_host_dict")
     def test_generate_ansible_hosts(self, mock_instance_host_dict):
@@ -272,30 +295,6 @@ class TestAnsibleConfigurator(TestCase):
         configuration = [{"subnet_cidrs": [21], "cloud_identifier": 13}]
         expected = [{'cloud_identifier': 13, 'provider_cidrs': [21]}]
         self.assertEqual(expected, ansible_configurator.get_cidrs(configuration))
-
-    def test_get_ansible_roles_empty(self):
-        self.assertEqual([], ansible_configurator.get_ansible_roles([], startup.LOG))
-
-    def test_get_ansible_roles(self):
-        ansible_roles = [{elem: elem for elem in ["file", "hosts", "name", "vars", "vars_file"]}]
-        self.assertEqual(ansible_roles, ansible_configurator.get_ansible_roles(ansible_roles, startup.LOG))
-
-    def test_get_ansible_roles_add(self):
-        ansible_roles = [{elem: elem for elem in ["file", "hosts", "name", "vars", "vars_file"]}]
-        ansible_roles_add = [{elem: elem for elem in ["file", "hosts", "name", "vars", "vars_file", "additional"]}]
-        self.assertEqual(ansible_roles, ansible_configurator.get_ansible_roles(ansible_roles_add, startup.LOG))
-
-    def test_get_ansible_roles_minus(self):
-        ansible_roles = [{elem: elem for elem in ["file", "hosts"]}]
-        self.assertEqual(ansible_roles, ansible_configurator.get_ansible_roles(ansible_roles, startup.LOG))
-
-    def test_get_ansible_roles_mismatch_hosts(self):
-        ansible_roles = [{"file": "file"}]
-        self.assertEqual([], ansible_configurator.get_ansible_roles(ansible_roles, startup.LOG))
-
-    def test_get_ansible_roles_mismatch_file(self):
-        ansible_roles = [{"hosts": "hosts"}]
-        self.assertEqual([], ansible_configurator.get_ansible_roles(ansible_roles, startup.LOG))
 
     def test_get_ansible_galaxy_roles_empty(self):
         self.assertEqual([], ansible_configurator.get_ansible_galaxy_roles([], startup.LOG))
@@ -349,26 +348,23 @@ class TestAnsibleConfigurator(TestCase):
     @patch("bibigrid.core.utility.ansible_configurator.generate_common_configuration_yaml")
     @patch("bibigrid.core.actions.list_clusters.dict_clusters")
     @patch("bibigrid.core.utility.ansible_configurator.generate_ansible_hosts_yaml")
-    @patch("bibigrid.core.utility.ansible_configurator.get_ansible_roles")
     @patch("bibigrid.core.utility.ansible_configurator.generate_site_file_yaml")
     @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
     @patch("bibigrid.core.utility.ansible_configurator.get_cidrs")
-    def test_configure_ansible_yaml(self, mock_cidrs, mock_yaml, mock_site, mock_roles, mock_hosts, mock_list,
+    def test_configure_ansible_yaml(self, mock_cidrs, mock_yaml, mock_site, mock_hosts, mock_list,
                                     mock_common, mock_worker, mock_write):
         mock_cidrs.return_value = 421
         mock_list.return_value = {2: 422}
-        mock_roles.return_value = 423
         provider = MagicMock()
         provider.cloud_specification = {"auth": {"username": "Default"}}
-        configuration = [{"sshUser": 42, "ansibleRoles": 21}]
+        configuration = [{"sshUser": 42, "userRoles": 21}]
         cluster_id = 2
         ansible_configurator.configure_ansible_yaml([provider], configuration, cluster_id, startup.LOG)
         mock_worker.assert_called_with(configuration, startup.LOG)
         mock_common.assert_called_with(cidrs=421, configurations=configuration, cluster_id=cluster_id, ssh_user=42,
                                        default_user="Default", log=startup.LOG)
         mock_hosts.assert_called_with(42, configuration, cluster_id, startup.LOG)
-        mock_site.assert_called_with(423)
-        mock_roles.assert_called_with(21, startup.LOG)
+        mock_site.assert_called_with(21)
         mock_cidrs.assert_called_with(configuration)
         mock_write.assert_called()
         expected = [call(aRP.WORKER_SPECIFICATION_FILE, mock_worker(), startup.LOG, False),


### PR DESCRIPTION
Closes #489

Using the key `partitions`:

```yaml
- type: de.NBI small + ephemeral
      image: ^Ubuntu 22\.04 LTS \(.*\)$
      count: 2
      partitions:
        - ephemeral
```

you can create additional partitions.

This pull request also includes a minor enhancement for the default configurations for slurm and ansible (see #485 and #475 ) by introducing the global keys:
```yaml
customAnsibleCfg: True # If True, changes in ansible.cfg are kept. Default False.
customSlurmTemplate: True # If True, changes in slurm.j2 are kept. Default False.
```
this is necessary to ensure users ansible and slurm configs get updated when BiBiGrid updates if they don't use a custom version.