### PR TITLE
Dirty fix for service being too fast for startup

### DIFF
--- a/bibigrid/core/utility/ansible_commands.py
+++ b/bibigrid/core/utility/ansible_commands.py
@@ -54,6 +54,6 @@ EXECUTE = (f"ansible-playbook {os.path.join(aRP.PLAYBOOK_PATH_REMOTE, aRP.SITE_Y
            "Execute ansible playbook. Be patient.")
 
 # ansible setup
-UPDATE = ("sudo apt-get update", "Update apt repository lists.")
+UPDATE = ("sleep 60 && sudo apt-get update", "Update apt repository lists.")  # dirty fix
 PYTHON3_PIP = "sudo apt-get install -y python3-pip", "Install python3 pip using apt."
 ANSIBLE_PASSLIB = ("sudo pip install ansible==6.6 passlib", "Install Ansible and Passlib using pip.")


### PR DESCRIPTION
This simply adds a 60 second waiting period before trying to update. In tests 10 seconds seemed to be enough, but I added a few extra seconds just to be sure.

The real solution will work with a while loop like:
```
WAIT_FOR_SERVICES = (
    "while [[ $(systemctl is-active {service}) == 'active' ]]; do echo 'Waiting for service {service}'; sleep 2; done",
    "Waiting for service {service}.")
```