### PR TITLE
Fixes cyclic imports, Improved Logging, Minor logging bug in terminate

### DIFF
--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -431,7 +431,8 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             ssh_handler.execute_ssh(ssh_data=ssh_data, log=self.log)
         self.log.info("Uploading Data")
         ssh_data = {"floating_ip": self.master_ip, "private_key": private_key, "username": self.ssh_user,
-                    "commands": commands, "filepaths": UPLOAD_FILEPATHS, "gateway": self.configurations[0].get("gateway", {}),
+                    "commands": commands, "filepaths": UPLOAD_FILEPATHS,
+                    "gateway": self.configurations[0].get("gateway", {}),
                     "timeout": self.ssh_timeout}
         ssh_handler.execute_ssh(ssh_data=ssh_data, log=self.log)
 

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import threading
 import traceback
+import os
 
 import paramiko
 import sympy
@@ -19,7 +20,10 @@ from bibigrid.core.utility.handler import ssh_handler
 from bibigrid.models import exceptions
 from bibigrid.models import return_threading
 from bibigrid.models.exceptions import ExecutionException, ConfigurationException
-from bibigrid.core.utility.statics.create_statics import *
+from bibigrid.core.utility.paths import ansible_resources_path as a_rp
+from bibigrid.core.utility.statics.create_statics import AC_NAME, KEY_NAME, DEFAULT_SECURITY_GROUP_NAME, \
+    WIREGUARD_SECURITY_GROUP_NAME, KEY_FOLDER, CLUSTER_MEMORY_PATH, MASTER_IDENTIFIER, WORKER_IDENTIFIER, \
+    VPNGTW_IDENTIFIER, UPLOAD_FILEPATHS
 
 
 class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
@@ -427,7 +431,7 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             ssh_handler.execute_ssh(ssh_data=ssh_data, log=self.log)
         self.log.info("Uploading Data")
         ssh_data = {"floating_ip": self.master_ip, "private_key": private_key, "username": self.ssh_user,
-                    "commands": commands, "filepaths": FILEPATHS, "gateway": self.configurations[0].get("gateway", {}),
+                    "commands": commands, "filepaths": UPLOAD_FILEPATHS, "gateway": self.configurations[0].get("gateway", {}),
                     "timeout": self.ssh_timeout}
         ssh_handler.execute_ssh(ssh_data=ssh_data, log=self.log)
 

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -2,12 +2,10 @@
 The cluster creation (master's creation, key creation, ansible setup and execution, ...) is done here
 """
 
-import os
 import shutil
 import subprocess
 import threading
 import traceback
-from functools import partial
 
 import paramiko
 import sympy
@@ -18,46 +16,10 @@ from bibigrid.core.utility import ansible_configurator
 from bibigrid.core.utility import id_generation
 from bibigrid.core.utility import image_selection
 from bibigrid.core.utility.handler import ssh_handler
-from bibigrid.core.utility.paths import ansible_resources_path as a_rp
-from bibigrid.core.utility.paths import bin_path
 from bibigrid.models import exceptions
 from bibigrid.models import return_threading
 from bibigrid.models.exceptions import ExecutionException, ConfigurationException
-
-PREFIX = "bibigrid"
-SEPARATOR = "-"
-PREFIX_WITH_SEP = PREFIX + SEPARATOR
-FILEPATHS = [(a_rp.PLAYBOOK_PATH, a_rp.PLAYBOOK_PATH_REMOTE), (bin_path.BIN_PATH, bin_path.BIN_PATH_REMOTE)]
-
-
-def get_identifier(identifier, cluster_id, additional=""):
-    """
-    This method does more advanced string formatting to generate master, vpngtw and worker names
-    @param identifier: master|vpngtw|worker
-    @param cluster_id: id of cluster
-    @param additional: an additional string to be added at the end
-    @return: the generated string
-    """
-    general = PREFIX_WITH_SEP + identifier + SEPARATOR + cluster_id
-    if additional or additional == 0:
-        return general + SEPARATOR + str(additional)
-    return general
-
-
-MASTER_IDENTIFIER = partial(get_identifier, identifier="master", additional="")
-WORKER_IDENTIFIER = partial(get_identifier, identifier="worker")
-VPN_WORKER_IDENTIFIER = partial(get_identifier, identifier="vpngtw")
-
-KEY_PREFIX = "tempKey_bibi"
-CONFIG_FOLDER = os.path.expanduser("~/.config/bibigrid/")
-KEY_FOLDER = os.path.join(CONFIG_FOLDER, "keys/")
-AC_NAME = "ac" + SEPARATOR + "{cluster_id}"
-KEY_NAME = KEY_PREFIX + SEPARATOR + "{cluster_id}"
-CLUSTER_MEMORY_FOLDER = KEY_FOLDER
-CLUSTER_MEMORY_FILE = ".bibigrid.mem"
-CLUSTER_MEMORY_PATH = os.path.join(CONFIG_FOLDER, CLUSTER_MEMORY_FILE)
-DEFAULT_SECURITY_GROUP_NAME = "default" + SEPARATOR + "{cluster_id}"
-WIREGUARD_SECURITY_GROUP_NAME = "wireguard" + SEPARATOR + "{cluster_id}"
+from bibigrid.core.utility.statics.create_statics import *
 
 
 class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
@@ -238,7 +200,7 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             raise ConfigurationException(f"MAC address for ip {configuration['private_v4']} not found.")
 
         # pylint: disable=comparison-with-callable
-        if identifier == VPN_WORKER_IDENTIFIER or (identifier == MASTER_IDENTIFIER and self.use_master_with_public_ip):
+        if identifier == VPNGTW_IDENTIFIER or (identifier == MASTER_IDENTIFIER and self.use_master_with_public_ip):
             configuration["floating_ip"] = \
                 provider.attach_available_floating_ip(network=external_network, server=server)["floating_ip_address"]
             if identifier == MASTER_IDENTIFIER:
@@ -303,12 +265,13 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         @param name: sever name
         @return:
         """
-        self.log.info("Creating volumes ...")
+        self.log.info(f"Creating volumes for {name}...")
         return_volumes = []
-
         group_instance = {"volumes": []}
         instance["group_instances"] = {name: group_instance}
+
         for i, volume in enumerate(instance.get("volumes", [])):
+            self.log.debug(f"Volume {i}: {volume}")
             if not volume.get("exists"):
                 if volume.get("permanent"):
                     infix = "perm"
@@ -332,10 +295,10 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
                     if not return_volume:
                         raise ConfigurationException(f"Snapshot {volume['snapshot']} not found!")
                 else:
-                    self.log.debug("Creating volume...")
                     return_volume = provider.create_volume(name=volume_name, size=volume.get("size", 50),
                                                            volume_type=volume.get("type"),
                                                            description=f"Created for {name}")
+                    self.log.info(f"Volumes {i} created for {name}...")
             return_volumes.append(return_volume)
         return return_volumes
 
@@ -382,7 +345,7 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             identifier = MASTER_IDENTIFIER
         elif configuration.get("vpnInstance"):
             instance_type = configuration["vpnInstance"]
-            identifier = VPN_WORKER_IDENTIFIER
+            identifier = VPNGTW_IDENTIFIER
         else:
             self.log.warning(
                 f"Configuration {configuration['cloud_identifier']} "

--- a/bibigrid/core/actions/list_clusters.py
+++ b/bibigrid/core/actions/list_clusters.py
@@ -6,7 +6,7 @@ This includes a method to create a dictionary containing all running clusters an
 import pprint
 import re
 
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER
 
 SERVER_REGEX = re.compile(r"^bibigrid-((master)-([a-zA-Z0-9]+)|(worker|vpngtw)-([a-zA-Z0-9]+)-\d+)$")
 
@@ -148,7 +148,7 @@ def get_master_access_ip(cluster_id, master_provider, log):
     """
     # TODO: maybe move the method from list_clusters as it is now independent of list_clusters
     log.info("Finding master ip for cluster %s...", cluster_id)
-    master = create.MASTER_IDENTIFIER(cluster_id=cluster_id)
+    master = MASTER_IDENTIFIER(cluster_id=cluster_id)
     server = master_provider.get_server(master)
     if server:
         return server.get("public_v4") or server.get("public_v6") or server.get("private_v4")

--- a/bibigrid/core/actions/terminate.py
+++ b/bibigrid/core/actions/terminate.py
@@ -154,7 +154,7 @@ def delete_security_groups(provider, cluster_id, security_groups, log, timeout=5
             try:
                 tmp_success = provider.delete_security_group(security_group_name)
             except ConflictException:
-                tmp_success = False
+                tmp_success = Falseall
             if tmp_success:
                 break
             if attempts < timeout:
@@ -228,7 +228,7 @@ def terminate_output(*, cluster_server_state, cluster_keypair_state, cluster_sec
     cluster_server_terminated = all(cluster_server_state)
     cluster_keypair_deleted = all(cluster_keypair_state)
     cluster_security_group_deleted = all(cluster_security_group_state)
-    cluster_volume_deleted = all([all(instance_volume_states) for instance_volume_states in cluster_volume_state])
+    cluster_volume_deleted = all(all(instance_volume_states) for instance_volume_states in cluster_volume_state)
     if cluster_existed:
         if cluster_server_terminated:
             log.info("Terminated all servers of cluster %s.", cluster_id)

--- a/bibigrid/core/actions/terminate.py
+++ b/bibigrid/core/actions/terminate.py
@@ -7,7 +7,8 @@ import os
 import re
 import time
 
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import DEFAULT_SECURITY_GROUP_NAME, WIREGUARD_SECURITY_GROUP_NAME, \
+    KEY_NAME, KEY_FOLDER, AC_NAME
 from bibigrid.models.exceptions import ConflictException
 
 
@@ -26,14 +27,14 @@ def terminate(cluster_id, providers, log, debug=False, assume_yes=False):
         if not input(f"DEBUG MODE: Any non-empty input to shutdown cluster {cluster_id}. "
                      "Empty input to exit with cluster still alive:"):
             return 0
-    security_groups = [create.DEFAULT_SECURITY_GROUP_NAME]
+    security_groups = [DEFAULT_SECURITY_GROUP_NAME]
     if len(providers) > 1:
-        security_groups.append(create.WIREGUARD_SECURITY_GROUP_NAME)
+        security_groups.append(WIREGUARD_SECURITY_GROUP_NAME)
     cluster_server_state = []
     cluster_keypair_state = []
     cluster_security_group_state = []
     cluster_volume_state = []
-    tmp_keyname = create.KEY_NAME.format(cluster_id=cluster_id)
+    tmp_keyname = KEY_NAME.format(cluster_id=cluster_id)
     local_keypairs_deleted = delete_local_keypairs(tmp_keyname, log)
     if assume_yes or local_keypairs_deleted or input(
             f"WARNING: No local temporary keyfiles found for cluster {cluster_id}. "
@@ -117,7 +118,7 @@ def delete_local_keypairs(tmp_keyname, log):
     """
     success = False
     log.info("Deleting Keypair locally...")
-    tmp_keypath = os.path.join(create.KEY_FOLDER, tmp_keyname)
+    tmp_keypath = os.path.join(KEY_FOLDER, tmp_keyname)
     pub_tmp_keypath = tmp_keypath + ".pub"
     if os.path.isfile(tmp_keypath):
         os.remove(tmp_keypath)
@@ -149,9 +150,10 @@ def delete_security_groups(provider, cluster_id, security_groups, log, timeout=5
         security_group_name = security_group_format.format(cluster_id=cluster_id)
         attempts = 0
         tmp_success = False
+        not_found = True
         while not tmp_success:
             try:
-                not_found = not provider.get_security_group(security_group_name)
+                not_found = not provider.get_security_group(security_group_name)  # TODO: Improve Code
                 tmp_success = provider.delete_security_group(security_group_name)
             except ConflictException:
                 tmp_success = False
@@ -183,7 +185,7 @@ def delete_application_credentials(master_provider, cluster_id, log):
     # implement deletion
     auth = master_provider.cloud_specification["auth"]
     if not auth.get("application_credential_id") or not auth.get("application_credential_secret"):
-        return master_provider.delete_application_credential_by_id_or_name(create.AC_NAME.format(cluster_id=cluster_id))
+        return master_provider.delete_application_credential_by_id_or_name(AC_NAME.format(cluster_id=cluster_id))
     log.info("Because you used application credentials to authenticate, "
              "no created application credentials need deletion.")
     return True
@@ -197,7 +199,7 @@ def delete_non_permanent_volumes(provider, cluster_id, log):
     @param log:
     @return: a list of the servers' (that were to be terminated) termination states
     """
-    log.info("Deleting tmp volumes on provider %s...", provider.cloud_specification['identifier'])
+    log.info("Deleting non permanent volumes on provider %s...", provider.cloud_specification['identifier'])
     volume_list = provider.list_volumes()
     cluster_volume_state = []
     volume_regex = re.compile(
@@ -228,7 +230,7 @@ def terminate_output(*, cluster_server_state, cluster_keypair_state, cluster_sec
     cluster_server_terminated = all(cluster_server_state)
     cluster_keypair_deleted = all(cluster_keypair_state)
     cluster_security_group_deleted = all(cluster_security_group_state)
-    cluster_volume_deleted = all(cluster_volume_state)
+    cluster_volume_deleted = all([all(instance_volume_states) for instance_volume_states in cluster_volume_state])
     if cluster_existed:
         if cluster_server_terminated:
             log.info("Terminated all servers of cluster %s.", cluster_id)
@@ -254,7 +256,7 @@ def terminate_output(*, cluster_server_state, cluster_keypair_state, cluster_sec
                         "\nAll servers terminated: %s"
                         "\nAll keys deleted: %s"
                         "\nAll security groups deleted: %s"
-                        "\nAll security groups deleted: %s", cluster_id, cluster_server_terminated,
+                        "\nAll volumes deleted: %s", cluster_id, cluster_server_terminated,
                         cluster_keypair_deleted, cluster_security_group_deleted, cluster_volume_deleted)
         if ac_state:
             log.info("Successfully handled application credential of cluster %s.", cluster_id)

--- a/bibigrid/core/actions/terminate.py
+++ b/bibigrid/core/actions/terminate.py
@@ -149,15 +149,13 @@ def delete_security_groups(provider, cluster_id, security_groups, log, timeout=5
     for security_group_format in security_groups:
         security_group_name = security_group_format.format(cluster_id=cluster_id)
         attempts = 0
-        tmp_success = False
-        not_found = True
+        tmp_success = not provider.get_security_group(security_group_name)
         while not tmp_success:
             try:
-                not_found = not provider.get_security_group(security_group_name)  # TODO: Improve Code
                 tmp_success = provider.delete_security_group(security_group_name)
             except ConflictException:
                 tmp_success = False
-            if tmp_success or not_found:
+            if tmp_success:
                 break
             if attempts < timeout:
                 attempts += 1
@@ -168,7 +166,7 @@ def delete_security_groups(provider, cluster_id, security_groups, log, timeout=5
                 log.error(f"Attempt to delete security group {security_group_name} on "
                           f"{provider.cloud_specification['identifier']} failed.")
                 break
-        log.info(f"Delete security_group {security_group_name} -> {tmp_success or not_found} on "
+        log.info(f"Delete security_group {security_group_name} -> {tmp_success} on "
                  f"{provider.cloud_specification['identifier']}.")
         success = success and tmp_success
     return success

--- a/bibigrid/core/actions/terminate.py
+++ b/bibigrid/core/actions/terminate.py
@@ -154,7 +154,8 @@ def delete_security_groups(provider, cluster_id, security_groups, log, timeout=5
             try:
                 tmp_success = provider.delete_security_group(security_group_name)
             except ConflictException:
-                tmp_success = Falseall
+                log.info(f"ConflictException on deletion attempt on {provider.cloud_specification['identifier']}.")
+                tmp_success = False
             if tmp_success:
                 break
             if attempts < timeout:

--- a/bibigrid/core/actions/update.py
+++ b/bibigrid/core/actions/update.py
@@ -2,7 +2,6 @@
 Module that contains methods to update the master playbook
 """
 
-from bibigrid.core.actions import create
 from bibigrid.core.actions.list_clusters import dict_clusters
 from bibigrid.core.utility.handler import cluster_ssh_handler
 
@@ -19,7 +18,7 @@ def update(creator, log):
         log.warning(f"There are still workers up! {workers}")
         return 1
     if master_ip and ssh_user and used_private_key:
-        master = create.MASTER_IDENTIFIER(cluster_id=creator.cluster_id)
+        master = creator.MASTER_IDENTIFIER(cluster_id=creator.cluster_id)
         server = creator.providers[0].get_server(master)
         creator.master_ip = master_ip
         creator.configurations[0]["private_v4"] = server["private_v4"]

--- a/bibigrid/core/utility/handler/cluster_ssh_handler.py
+++ b/bibigrid/core/utility/handler/cluster_ssh_handler.py
@@ -4,7 +4,8 @@ This module gets information about ssh connection.
 
 import os
 
-from bibigrid.core.actions import create, list_clusters
+from bibigrid.core.actions import list_clusters
+from bibigrid.core.utility.statics.create_statics import KEY_FOLDER, KEY_NAME
 
 
 def get_ssh_connection_info(cluster_id, master_provider, master_configuration, log):
@@ -34,7 +35,7 @@ def get_ssh_connection_info(cluster_id, master_provider, master_configuration, l
                 used_private_key = private_key
                 break
     if not used_private_key:
-        private_key = os.path.join(create.KEY_FOLDER, create.KEY_NAME.format(cluster_id=cluster_id))
+        private_key = os.path.join(KEY_FOLDER, KEY_NAME.format(cluster_id=cluster_id))
         if os.path.isfile(private_key):
             used_private_key = private_key
     return master_ip, ssh_user, used_private_key

--- a/bibigrid/core/utility/id_generation.py
+++ b/bibigrid/core/utility/id_generation.py
@@ -4,7 +4,7 @@ Generates ids and munge keys
 
 import shortuuid
 
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER, VPNGTW_IDENTIFIER, WORKER_IDENTIFIER
 
 MAX_ID_LENGTH = 15
 CLUSTER_UUID_ALPHABET = '0123456789abcdefghijkmnopqrstuvwxyz'
@@ -43,9 +43,9 @@ def is_unique_cluster_id(cluster_id, providers):
     """
     for provider in providers:
         for server in provider.list_servers():
-            master = create.MASTER_IDENTIFIER(cluster_id=cluster_id)
-            vpngtw = create.VPN_WORKER_IDENTIFIER(cluster_id=cluster_id)
-            worker = create.WORKER_IDENTIFIER(cluster_id=cluster_id)
+            master = MASTER_IDENTIFIER(cluster_id=cluster_id)
+            vpngtw = VPNGTW_IDENTIFIER(cluster_id=cluster_id)
+            worker = WORKER_IDENTIFIER(cluster_id=cluster_id)
             if server["name"] in [master, vpngtw, worker]:
                 return False
     return True

--- a/bibigrid/core/utility/statics/create_statics.py
+++ b/bibigrid/core/utility/statics/create_statics.py
@@ -1,0 +1,43 @@
+"""
+Containg static variables for create.py to avoid cyclic imports
+"""
+
+import os
+from functools import partial
+
+from bibigrid.core.utility.paths import ansible_resources_path as a_rp
+from bibigrid.core.utility.paths import bin_path
+
+
+def get_identifier(identifier, cluster_id, additional=""):
+    """
+    This method does more advanced string formatting to generate master, vpngtw and worker names
+    @param identifier: master|vpngtw|worker
+    @param cluster_id: id of cluster
+    @param additional: an additional string to be added at the end
+    @return: the generated string
+    """
+    general = PREFIX_WITH_SEP + identifier + SEPARATOR + cluster_id
+    if additional or additional == 0:
+        return general + SEPARATOR + str(additional)
+    return general
+
+
+PREFIX = "bibigrid"
+SEPARATOR = "-"
+PREFIX_WITH_SEP = PREFIX + SEPARATOR
+FILEPATHS = [(a_rp.PLAYBOOK_PATH, a_rp.PLAYBOOK_PATH_REMOTE), (bin_path.BIN_PATH, bin_path.BIN_PATH_REMOTE)]
+MASTER_IDENTIFIER = partial(get_identifier, identifier="master", additional="")
+WORKER_IDENTIFIER = partial(get_identifier, identifier="worker")
+VPNGTW_IDENTIFIER = partial(get_identifier, identifier="vpngtw")
+
+KEY_PREFIX = "tempKey_bibi"
+CONFIG_FOLDER = os.path.expanduser("~/.config/bibigrid/")
+KEY_FOLDER = os.path.join(CONFIG_FOLDER, "keys/")
+AC_NAME = "ac" + SEPARATOR + "{cluster_id}"
+KEY_NAME = KEY_PREFIX + SEPARATOR + "{cluster_id}"
+CLUSTER_MEMORY_FOLDER = KEY_FOLDER
+CLUSTER_MEMORY_FILE = ".bibigrid.mem"
+CLUSTER_MEMORY_PATH = os.path.join(CONFIG_FOLDER, CLUSTER_MEMORY_FILE)
+DEFAULT_SECURITY_GROUP_NAME = "default" + SEPARATOR + "{cluster_id}"
+WIREGUARD_SECURITY_GROUP_NAME = "wireguard" + SEPARATOR + "{cluster_id}"

--- a/bibigrid/core/utility/statics/create_statics.py
+++ b/bibigrid/core/utility/statics/create_statics.py
@@ -26,7 +26,7 @@ def get_identifier(identifier, cluster_id, additional=""):
 PREFIX = "bibigrid"
 SEPARATOR = "-"
 PREFIX_WITH_SEP = PREFIX + SEPARATOR
-FILEPATHS = [(a_rp.PLAYBOOK_PATH, a_rp.PLAYBOOK_PATH_REMOTE), (bin_path.BIN_PATH, bin_path.BIN_PATH_REMOTE)]
+UPLOAD_FILEPATHS = [(a_rp.PLAYBOOK_PATH, a_rp.PLAYBOOK_PATH_REMOTE), (bin_path.BIN_PATH, bin_path.BIN_PATH_REMOTE)]
 MASTER_IDENTIFIER = partial(get_identifier, identifier="master", additional="")
 WORKER_IDENTIFIER = partial(get_identifier, identifier="worker")
 VPNGTW_IDENTIFIER = partial(get_identifier, identifier="vpngtw")

--- a/bibigrid/openstack/openstack_provider.py
+++ b/bibigrid/openstack/openstack_provider.py
@@ -13,7 +13,7 @@ from keystoneauth1.exceptions.http import NotFound
 from keystoneauth1.identity import v3
 
 from bibigrid.core import provider
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import PREFIX_WITH_SEP
 from bibigrid.core.actions import version
 from bibigrid.models.exceptions import ExecutionException, ConflictException, ImageDeactivatedException
 
@@ -213,7 +213,7 @@ class OpenstackProvider(provider.Provider):  # pylint: disable=too-many-public-m
             if snapshot["status"] == "available":
                 LOG.debug("Snapshot %s is available.", {snapshot_name_or_id})
                 size = snapshot["size"]
-                name = volume_name_or_id or (create.PREFIX_WITH_SEP + snapshot["name"])
+                name = volume_name_or_id or (PREFIX_WITH_SEP + snapshot["name"])
                 description = description or f"Created from snapshot {snapshot_name_or_id} by BiBiGrid"
                 volume = self.cinder.volumes.create(size=size, snapshot_id=snapshot["id"], name=name,
                                                     description=description)

--- a/tests/unit_tests/test_ansible_configurator.py
+++ b/tests/unit_tests/test_ansible_configurator.py
@@ -3,6 +3,7 @@ Tests for ansible_configurator
 """
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch, call, mock_open, ANY
+import os
 
 import bibigrid.core.utility.paths.ansible_resources_path as aRP
 from bibigrid.core import startup
@@ -99,7 +100,7 @@ class TestAnsibleConfigurator(TestCase):
         cluster_id = "21"
         default_user = "ubuntu"
         ssh_user = "test"
-        configuration = [{}]
+        configurations = [{}]
         common_configuration_yaml = {'bibigrid_version': version.__version__, 'cloud_scheduling': {'sshTimeout': 5},
                                      'cluster_cidrs': cidrs, 'cluster_id': cluster_id, 'default_user': default_user,
                                      'dns_server_list': ['8.8.8.8'], 'enable_ide': False, 'enable_nfs': False,
@@ -110,10 +111,12 @@ class TestAnsibleConfigurator(TestCase):
                                                                            'SuspendTimeout': 60, 'TreeWidth': 128},
                                                     'munge_key': 'TO_BE_FILLED'}, 'ssh_user': ssh_user,
                                      'use_master_as_compute': True}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         # munge key is randomly generated
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
@@ -123,7 +126,7 @@ class TestAnsibleConfigurator(TestCase):
         cluster_id = "21"
         default_user = "ubuntu"
         ssh_user = "test"
-        configuration = [
+        configurations = [
             {elem: "True" for elem in ["localFS", "localDNSlookup", "useMasterAsCompute", "slurm", "zabbix", "ide"]}]
         common_configuration_yaml = {'bibigrid_version': version.__version__, 'cloud_scheduling': {'sshTimeout': 5},
                                      'cluster_cidrs': cidrs, 'cluster_id': cluster_id, 'default_user': default_user,
@@ -140,15 +143,17 @@ class TestAnsibleConfigurator(TestCase):
                                      'zabbix_conf': {'admin_password': 'bibigrid', 'db': 'zabbix',
                                                      'db_password': 'zabbix', 'db_user': 'zabbix',
                                                      'server_name': 'bibigrid', 'timezone': 'Europe/Berlin'}}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
     def test_generate_common_configuration_nfs_shares(self):
-        configuration = [{"nfs": "True", "nfsShares": ["/vil/mil"]}]
+        configurations = [{"nfs": "True", "nfsShares": ["/vil/mil"]}]
         cidrs = "42"
         cluster_id = "21"
         default_user = "ubuntu"
@@ -165,15 +170,17 @@ class TestAnsibleConfigurator(TestCase):
                                                                            'SuspendTimeout': 60, 'TreeWidth': 128},
                                                     'munge_key': 'TO_BE_FILLED'}, 'ssh_user': ssh_user,
                                      'use_master_as_compute': True}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
     def test_generate_common_configuration_nfs(self):
-        configuration = [{"nfs": "True"}]
+        configurations = [{"nfs": "True"}]
         cidrs = "42"
         cluster_id = "21"
         default_user = "ubuntu"
@@ -189,15 +196,17 @@ class TestAnsibleConfigurator(TestCase):
                                                                            'SuspendTimeout': 60, 'TreeWidth': 128},
                                                     'munge_key': 'TO_BE_FILLED'}, 'ssh_user': ssh_user,
                                      'use_master_as_compute': True}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
     def test_generate_common_configuration_ext_nfs_shares(self):
-        configuration = [{"nfs": "True", "extNfsShares": ["/vil/mil"]}]
+        configurations = [{"nfs": "True", "extNfsShares": ["/vil/mil"]}]
         cidrs = "42"
         cluster_id = "21"
         default_user = "ubuntu"
@@ -214,15 +223,17 @@ class TestAnsibleConfigurator(TestCase):
                                                                            'SuspendTimeout': 60, 'TreeWidth': 128},
                                                     'munge_key': 'YryJVnqgg24Ksf8zXQtbct3nuXrMSi9N'},
                                      'ssh_user': ssh_user, 'use_master_as_compute': True}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
     def test_generate_common_configuration_ide_and_wireguard(self):
-        configuration = [{"ide": "Some1", "ideConf": {"key1": "Some2"}, "wireguard_peer": 21}, {"wireguard_peer": 42}]
+        configurations = [{"ide": "Some1", "ideConf": {"key1": "Some2"}, "wireguard_peer": 21}, {"wireguard_peer": 42}]
         cidrs = "42"
         cluster_id = "21"
         default_user = "ubuntu"
@@ -240,10 +251,12 @@ class TestAnsibleConfigurator(TestCase):
                                                     'munge_key': 'b4pPb7bQTHzTDtGsqo2pYkGdpa87TtPD'},
                                      'ssh_user': 'test', 'use_master_as_compute': True,
                                      'wireguard_common': {'listen_port': 51820, 'mask_bits': 24, 'peers': [21, 42]}}
-        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs, configuration,
-                                                                                                 cluster_id, ssh_user,
-                                                                                                 default_user,
-                                                                                                 startup.LOG)
+        generated_common_configuration = ansible_configurator.generate_common_configuration_yaml(cidrs=cidrs,
+                                                                                                 configurations=configurations,
+                                                                                                 cluster_id=cluster_id,
+                                                                                                 ssh_user=ssh_user,
+                                                                                                 default_user=default_user,
+                                                                                                 log=startup.LOG)
         common_configuration_yaml["slurm_conf"]["munge_key"] = generated_common_configuration["slurm_conf"]["munge_key"]
         self.assertEqual(common_configuration_yaml, generated_common_configuration)
 
@@ -369,15 +382,12 @@ class TestAnsibleConfigurator(TestCase):
                     call(aRP.SITE_CONFIG_FILE, mock_site(), startup.LOG, False)]
         self.assertEqual(expected, mock_yaml.call_args_list)
 
+    @patch("bibigrid.core.utility.paths.ansible_resources_path.HOST_VARS_FOLDER", "mock_path")
     @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
-    @patch("bibigrid.core.utility.ansible_configurator.create.WORKER_IDENTIFIER")
-    def test_write_worker_host_vars(self, mock_worker_identifier, mock_write_yaml):
-        mock_worker_identifier.side_effect = lambda cluster_id, additional: f"worker-{cluster_id}-{additional}"
-
+    def test_write_worker_host_vars(self, mock_write_yaml):
         cluster_id = "foo"
         worker_count = 0
         log = MagicMock()
-
         worker = {
             "count": 2,
             "volumes": [
@@ -392,23 +402,23 @@ class TestAnsibleConfigurator(TestCase):
 
         expected_calls = [
             call(
-                "/home/xaver/Documents/Repos/bibigrid/resources/playbook/host_vars/worker-foo-0.yaml",
+                os.path.join("mock_path", "bibigrid-worker-foo-0.yaml"),
                 {
                     "volumes": [
                         {"name": "volume1", "exists": True},
-                        {"permanent": True, "name": "worker-foo-0-perm-1-volume2"},
-                        {"tmp": True, "name": "worker-foo-0-tmp-2"},
+                        {"permanent": True, "name": "bibigrid-worker-foo-0-perm-1-volume2"},
+                        {"tmp": True, "name": "bibigrid-worker-foo-0-tmp-2"},
                     ]
                 },
                 log,
             ),
             call(
-                "/home/xaver/Documents/Repos/bibigrid/resources/playbook/host_vars/worker-foo-1.yaml",
+                os.path.join("mock_path", "bibigrid-worker-foo-1.yaml"),
                 {
                     "volumes": [
                         {"name": "volume1", "exists": True},
-                        {"permanent": True, "name": "worker-foo-1-perm-1-volume2"},
-                        {"tmp": True, "name": "worker-foo-1-tmp-2"},
+                        {"permanent": True, "name": "bibigrid-worker-foo-1-perm-1-volume2"},
+                        {"tmp": True, "name": "bibigrid-worker-foo-1-tmp-2"},
                     ]
                 },
                 log,
@@ -419,47 +429,14 @@ class TestAnsibleConfigurator(TestCase):
         ansible_configurator.write_worker_host_vars(
             cluster_id=cluster_id,
             worker=worker,
-            worker_dict=worker_dict,
             worker_count=worker_count,
             log=log,
-        )
-
-        # Validate WORKER_IDENTIFIER calls
-        mock_worker_identifier.assert_has_calls(
-            [call(cluster_id="foo", additional=0), call(cluster_id="foo", additional=1)],
-            any_order=False,
         )
 
         # Validate write_yaml calls
         mock_write_yaml.assert_has_calls(expected_calls, any_order=False)
 
-    @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
-    def test_write_worker_host_vars_on_demand_false(self, mock_write_yaml):
-        """
-        This tests that no host_vars is written if on_demand is false.
-        Currently, that would result in an empty host vars that is not needed.
-        @param mock_write_yaml:
-        @return:
-        """
-        cluster_id = "foo"
-        worker_count = 0
-        log = MagicMock()
-
-        worker = {"count": 2, "volumes": [{"name": "volume1", "exists": True}]}
-        worker_dict = {"on_demand": False}
-
-        # Call the function
-        ansible_configurator.write_worker_host_vars(
-            cluster_id=cluster_id,
-            worker=worker,
-            worker_dict=worker_dict,
-            worker_count=worker_count,
-            log=log,
-        )
-
-        # Assert no write_yaml calls were made
-        mock_write_yaml.assert_not_called()
-
+    @patch("bibigrid.core.utility.paths.ansible_resources_path.GROUP_VARS_FOLDER", "mock_path")
     @patch("bibigrid.core.utility.ansible_configurator.write_worker_host_vars")
     @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
     def test_write_worker_vars(self, mock_write_yaml, mock_write_worker_host_vars):
@@ -511,20 +488,19 @@ class TestAnsibleConfigurator(TestCase):
         )
         # Assert group_vars were written correctly
         mock_write_yaml.assert_any_call(
-            "/home/xaver/Documents/Repos/bibigrid/resources/playbook/group_vars/bibigrid_worker_foo_0_1.yaml",
+            os.path.join("mock_path", "bibigrid_worker_foo_0_1.yaml"),
             expected_group_vars,
             log
         )
-
         # Ensure write_worker_host_vars was called
         mock_write_worker_host_vars.assert_called_once_with(
             cluster_id=cluster_id,
             worker=worker,
-            worker_dict=expected_group_vars,
             worker_count=worker_count,
             log=log
         )
 
+    @patch("bibigrid.core.utility.paths.ansible_resources_path.HOST_VARS_FOLDER", "mock_path")
     @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
     def test_write_vpn_var(self, mock_write_yaml):
         provider = MagicMock()
@@ -574,11 +550,12 @@ class TestAnsibleConfigurator(TestCase):
         )
 
         mock_write_yaml.assert_called_once_with(
-            "/home/xaver/Documents/Repos/bibigrid/resources/playbook/host_vars/bibigrid-vpngtw-foo-0.yaml",
+            os.path.join("mock_path", "bibigrid-vpngtw-foo-0.yaml"),
             expected_host_vars,
             log
         )
 
+    @patch("bibigrid.core.utility.paths.ansible_resources_path.GROUP_VARS_FOLDER", "mock_path")
     @patch("bibigrid.core.utility.ansible_configurator.write_yaml")
     def test_write_master_var(self, mock_write_yaml):
         provider = MagicMock()
@@ -627,7 +604,7 @@ class TestAnsibleConfigurator(TestCase):
 
         # Validate the output
         mock_write_yaml.assert_called_once_with(
-            "/home/xaver/Documents/Repos/bibigrid/resources/playbook/group_vars/master.yaml",
+            os.path.join("mock_path", "master.yaml"),
             expected_master_vars,
             log,
         )

--- a/tests/unit_tests/test_create.py
+++ b/tests/unit_tests/test_create.py
@@ -160,7 +160,7 @@ class TestCreate(TestCase):
                                                   cluster_id=creator.cluster_id, log=startup.LOG)
         ssh_data = {'floating_ip': creator.master_ip, 'private_key': create.KEY_FOLDER + creator.key_name,
                     'username': creator.ssh_user, 'commands': [mock_ac_ssh()] + ssh_handler.ANSIBLE_START,
-                    'filepaths': create.FILEPATHS, 'gateway': {}, 'timeout': 5}
+                    'filepaths': create.UPLOAD_FILEPATHS, 'gateway': {}, 'timeout': 5}
         mock_execute_ssh.assert_called_with(ssh_data=ssh_data, log=startup.LOG)
 
     @patch.object(create.Create, "generate_keypair")

--- a/tests/unit_tests/test_create.py
+++ b/tests/unit_tests/test_create.py
@@ -98,7 +98,7 @@ class TestCreate(TestCase):
 
         # Test for VPN args preparation
         identifier, instance_type = creator.prepare_vpn_or_master_args(configuration)
-        self.assertEqual((create.VPN_WORKER_IDENTIFIER, "Some"), (identifier, instance_type))
+        self.assertEqual((create.VPNGTW_IDENTIFIER, "Some"), (identifier, instance_type))
 
     @patch("bibigrid.core.utility.handler.ssh_handler.execute_ssh")
     def test_initialize_master(self, mock_execute_ssh):

--- a/tests/unit_tests/test_id_generation.py
+++ b/tests/unit_tests/test_id_generation.py
@@ -4,7 +4,7 @@ Module to test id_generation
 from unittest import TestCase
 from unittest.mock import Mock, MagicMock, patch
 
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER
 from bibigrid.core.utility import id_generation
 
 
@@ -35,7 +35,7 @@ class TestIDGeneration(TestCase):
         cluster_id = "42"
         provider = Mock()
         provider.list_servers = MagicMock(
-            return_value=[{"name": create.MASTER_IDENTIFIER(cluster_id=cluster_id)}])
+            return_value=[{"name": MASTER_IDENTIFIER(cluster_id=cluster_id)}])
         self.assertFalse(id_generation.is_unique_cluster_id(str(cluster_id), [provider]))
         provider.list_servers.assert_called()
 
@@ -43,6 +43,6 @@ class TestIDGeneration(TestCase):
         cluster_id = 42
         provider = Mock()
         provider.list_servers = MagicMock(
-            return_value=[{"name": create.MASTER_IDENTIFIER(cluster_id=str(cluster_id + 1))}])
+            return_value=[{"name": MASTER_IDENTIFIER(cluster_id=str(cluster_id + 1))}])
         self.assertTrue(id_generation.is_unique_cluster_id(str(cluster_id), [provider]))
         provider.list_servers.assert_called()

--- a/tests/unit_tests/test_list_clusters.py
+++ b/tests/unit_tests/test_list_clusters.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from bibigrid.core import startup
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import WORKER_IDENTIFIER, VPNGTW_IDENTIFIER, MASTER_IDENTIFIER
 from bibigrid.core.actions import list_clusters
 
 
@@ -15,7 +15,7 @@ class TestList(TestCase):
     """
 
     def test_setup(self):
-        for identifier in [create.WORKER_IDENTIFIER, create.VPN_WORKER_IDENTIFIER, create.MASTER_IDENTIFIER]:
+        for identifier in [WORKER_IDENTIFIER, VPNGTW_IDENTIFIER, MASTER_IDENTIFIER]:
             cluster_id = "42"
             provider = Mock()
             provider.name = "name"
@@ -29,7 +29,7 @@ class TestList(TestCase):
             self.assertEqual("21", server["cloud_specification"])
 
     def test_setup_already(self):
-        for identifier in [create.WORKER_IDENTIFIER, create.VPN_WORKER_IDENTIFIER, create.MASTER_IDENTIFIER]:
+        for identifier in [WORKER_IDENTIFIER, VPNGTW_IDENTIFIER, MASTER_IDENTIFIER]:
             cluster_id = "42"
             provider = Mock()
             provider.name = "name"
@@ -52,6 +52,6 @@ class TestList(TestCase):
         provider.NAME = "Mock"
         provider.cloud_specification = {"identifier": "21"}
         provider.list_servers.return_value = [{'name': identifier(cluster_id=cluster_id) + "-0"} for identifier in
-                                              [create.WORKER_IDENTIFIER, create.VPN_WORKER_IDENTIFIER]] + [
-                                                 {'name': create.MASTER_IDENTIFIER(cluster_id=cluster_id)}]
+                                              [WORKER_IDENTIFIER, VPNGTW_IDENTIFIER]] + [
+                                                 {'name': MASTER_IDENTIFIER(cluster_id=cluster_id)}]
         self.assertEqual(expected, list_clusters.dict_clusters([provider], startup.LOG))

--- a/tests/unit_tests/test_terminate_cluster.py
+++ b/tests/unit_tests/test_terminate_cluster.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch, call
 
 from bibigrid.core import startup
-from bibigrid.core.actions import create
+from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER, KEY_NAME
 from bibigrid.core.actions import terminate
 
 
@@ -21,18 +21,18 @@ class TestTerminate(TestCase):
         provider = MagicMock()
         provider.cloud_specification["auth"]["project_name"] = 32
         cluster_id = 42
-        provider.list_servers.return_value = [{"name": create.MASTER_IDENTIFIER(cluster_id=str(cluster_id)), "id": 21}]
+        provider.list_servers.return_value = [{"name": MASTER_IDENTIFIER(cluster_id=str(cluster_id)), "id": 21}]
         provider.delete_server.return_value = True
         provider.delete_keypair.return_value = True
         provider.delete_volume.return_value = True
         provider.list_volumes.return_value = [
-            {"name": f"{create.MASTER_IDENTIFIER(cluster_id=str(cluster_id))}-tmp-0", "id": 42}]
+            {"name": f"{MASTER_IDENTIFIER(cluster_id=str(cluster_id))}-tmp-0", "id": 42}]
         provider.list_volumes([{"name": "bibigrid-master-i950vaoqzfbwpnq-tmp-0"}])
         provider.delete_security_group.return_value = True
         provider.delete_application_credentials.return_value = True
         terminate.terminate(str(cluster_id), [provider], startup.LOG, False, True)
         provider.delete_server.assert_called_with(21)
-        provider.delete_keypair.assert_called_with(create.KEY_NAME.format(cluster_id=cluster_id))
+        provider.delete_keypair.assert_called_with(KEY_NAME.format(cluster_id=cluster_id))
         mock_output.assert_called_with(cluster_server_state=[provider.delete_server.return_value],
                                        cluster_keypair_state=[provider.delete_keypair.return_value],
                                        cluster_security_group_state=[provider.delete_security_group.return_value],
@@ -49,18 +49,18 @@ class TestTerminate(TestCase):
         provider[0].specification["auth"]["project_name"] = "test_project_name"
         cluster_id = 42
         provider.list_servers.return_value = [
-            {"name": create.MASTER_IDENTIFIER(cluster_id=str(cluster_id + 1)), "id": 21}]
+            {"name": MASTER_IDENTIFIER(cluster_id=str(cluster_id + 1)), "id": 21}]
         provider.delete_keypair.return_value = False
         terminate.terminate(str(cluster_id), [provider], startup.LOG, False, True)
         provider.delete_server.assert_not_called()
         provider.delete_keypair.assert_called_with(
-            create.KEY_NAME.format(cluster_id=str(cluster_id)))  # since keypair is not called
+            KEY_NAME.format(cluster_id=str(cluster_id)))  # since keypair is not called
 
     def test_delete_non_pemanent_volumes(self):
         cluster_id = "1234"
         provider = MagicMock()
         log = MagicMock()
-        cluster_id=21
+        cluster_id = 21
 
         # List of test volumes
         volumes = [


### PR DESCRIPTION
In order to avoid cyclic imports, frequently needed static variables form the create module are now moved to create_static in the new statics folder. Another option would've been to move them into the __init__.py of the encompassing module, but that felt less clear.

A few additional debug messages have been added as well as a small fix in the terminate action logging which caused volume deletion to always log as False despite being successful.