### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/bibigrid/core/actions/terminate.py
+++ b/bibigrid/core/actions/terminate.py
@@ -118,18 +118,18 @@ def delete_local_keypairs(tmp_keyname, log):
     """
     success = False
     log.info("Deleting Keypair locally...")
-    tmp_keypath = os.path.join(KEY_FOLDER, tmp_keyname)
-    pub_tmp_keypath = tmp_keypath + ".pub"
-    if os.path.isfile(tmp_keypath):
+    tmp_keypath = os.path.normpath(os.path.join(KEY_FOLDER, tmp_keyname))
+    pub_tmp_keypath = os.path.normpath(tmp_keypath + ".pub")
+    if tmp_keypath.startswith(KEY_FOLDER) and os.path.isfile(tmp_keypath):
         os.remove(tmp_keypath)
         success = True
     else:
-        log.warning(f"Unable to find private keyfile '{tmp_keypath}' locally. No local private keyfile deleted.")
-    if os.path.isfile(pub_tmp_keypath):
+        log.warning(f"Unable to find private keyfile '{tmp_keypath}' locally or path is invalid. No local private keyfile deleted.")
+    if pub_tmp_keypath.startswith(KEY_FOLDER) and os.path.isfile(pub_tmp_keypath):
         os.remove(pub_tmp_keypath)
         success = True
     else:
-        log.warning(f"Unable to find public keyfile '{pub_tmp_keypath}' locally. No local public keyfile deleted.")
+        log.warning(f"Unable to find public keyfile '{pub_tmp_keypath}' locally or path is invalid. No local public keyfile deleted.")
     return success
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/BiBiServ/bibigrid/security/code-scanning/22](https://github.com/BiBiServ/bibigrid/security/code-scanning/22)

To fix the problem, we need to validate the `cluster_id` before using it to construct file paths. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. This approach will prevent directory traversal attacks and ensure the file operations are performed within the intended directory.

1. Normalize the constructed file paths using `os.path.normpath`.
2. Ensure the normalized paths start with the intended root directory (`KEY_FOLDER`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
