### PR TITLE
Real memory fix

### DIFF
--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -88,7 +88,7 @@ NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=
 {% endfor %}
 
 {% for key, value in partitions.items() %}
-PartitionName={{ key }} Nodes={{ value | join(",") }}
+PartitionName={{ key }} Nodes={{ value | join(",") }}{{ " Default=YES" if loop.last else ""}}
 {% endfor %}
 
 # JobSubmitPlugin

--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -76,7 +76,7 @@ SlurmdLogFile=/var/log/slurm/slurmd.log
 {% endif %}
 {% set _ = node_groups.append(node.name) %}
 {# MiB to MB #}
-{% set mem = (node.flavor.ram * 1.048576) | int %}
+{% set mem = (node.flavor.ram * 0.98 - 150) | int %} # EXPERIMENTAL
 NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=1 RealMemory={{ mem }} MemSpecLimit={{ [mem//4 + 1000, 8000] | min }} State={{node.state }} {{"Features=" + (node.features | join(",")) if node.features is defined }}# {{ node.cloud_identifier }}
 {% for partition in node.partitions %}
 {% if partition not in partitions %}

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/042-slurm.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/042-slurm.yaml
@@ -81,6 +81,7 @@
     owner: slurm
     group: root
     mode: "0o444"
+    force: true
 
 - name: Create Job Container configuration
   template:
@@ -89,6 +90,7 @@
     owner: slurm
     group: root
     mode: "0o444"
+    force: true
 
 - name: Slurm cgroup configuration
   copy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ rest = [
     "uvicorn~=0.34.1"
 ]
 dev = [
+    "ansible>=7.0.0",
     "ansible_lint==24.9.0",
     "pylint==3.3",
     "httpx==0.28.1"


### PR DESCRIPTION
This fixes the issue that more real memory was set than total memory present on the machine due to reservations by the os by estimating the size of those reservations.

In addition a Slurm warning regarding the default partition has been fixed (the warning itself caused no issues since we allow Slurm to schedule jobs to all partitions).
`force: true` has been explicitly set for the template creation of slurm.conf. Though the documentation says that this is the default, it seems as if ansible somtimes is not overwriting the slurm.conf even though the content changed. This might be a fluke though.