### PR TITLE
Fix docker restarts even when no change

### DIFF
--- a/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
+++ b/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
@@ -3,10 +3,14 @@
     name: nfs-kernel-server
     state: restarted
 
-- name: Docker
+- name: Restart Docker and its socket
   systemd:
-    name: docker
+    name: "{{ item }}"
     state: restarted
+  loop:
+    - docker.socket
+    - docker
+
 
 - name: Munge
   systemd:

--- a/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
+++ b/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
@@ -3,7 +3,7 @@
     name: nfs-kernel-server
     state: restarted
 
-- name: Restart Docker and its socket
+- name: Docker
   systemd:
     name: "{{ item }}"
     state: restarted

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
@@ -37,7 +37,7 @@
     owner: root
     group: root
     mode: "0o644"
-  register: docker_config
+  notify: Docker
 
 - name: Create docker group and change GID
   group:
@@ -50,11 +50,3 @@
     name: ubuntu
     append: true
     groups: docker
-
-- name: (Re-)start docker socket
-  systemd:
-    name: docker.socket
-    state: restarted
-  notify:
-    Docker
-  when: docker_config is changed

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
@@ -37,8 +37,7 @@
     owner: root
     group: root
     mode: "0o644"
-  notify:
-    Docker
+  register: docker_config
 
 - name: Create docker group and change GID
   group:
@@ -56,3 +55,6 @@
   systemd:
     name: docker.socket
     state: restarted
+  notify:
+    Docker
+  when: docker_config is changed


### PR DESCRIPTION
Included socket restart in Docker handler to make both conditional to change. **If for any reason it is necessary to run the socket restart immediately, we have to flush the handlers.**