### PR TITLE
Descriptions say ./bibigrid.sh instead of bibigrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Refer to BiBiGrid's [Command Line Interface documentation](documentation/markdow
 
 A first execution run through could be:
 
-1. `./bibigrid.sh create -i [path-to-bibigrid.yaml]`: checks the configuration
-2. `./bibigrid.sh create -i [path-to-bibigrid.yaml]'`: creates the cluster (execute only if check was successful)
+1. `bibigrid create -i [path-to-bibigrid.yaml]`: checks the configuration
+2. `bibigrid create -i [path-to-bibigrid.yaml]'`: creates the cluster (execute only if check was successful)
 3. Use **BiBiGrid's create output** to investigate the created cluster further. Especially connecting to the ide might be helpful. 
 Otherwise, connect using ssh.
 4. While in ssh try `sinfo` to printing node info

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -598,10 +598,10 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         self.log.log(42, f"Cluster {self.cluster_id} with master {self.master_ip} up and running!")
         self.log.log(42, f"SSH: ssh -i '{KEY_FOLDER}{self.key_name}' {self.ssh_user}@{ssh_ip}"
                          f"{f' -p {port}' if gateway else ''}")
-        self.log.log(42, f"Terminate cluster: ./bibigrid.sh terminate -i '{self.config_path}' -cid {self.cluster_id}")
-        self.log.log(42, f"Detailed cluster info: ./bibigrid.sh list -i '{self.config_path}' -cid {self.cluster_id}")
+        self.log.log(42, f"Terminate cluster: bibigrid.sh terminate -i '{self.config_path}' -cid {self.cluster_id}")
+        self.log.log(42, f"Detailed cluster info: bibigrid.sh list -i '{self.config_path}' -cid {self.cluster_id}")
         if self.configurations[0].get("ide"):
-            self.log.log(42, f"IDE Port Forwarding: ./bibigrid.sh ide -i '{self.config_path}' -cid {self.cluster_id}")
+            self.log.log(42, f"IDE Port Forwarding: bibigrid.sh ide -i '{self.config_path}' -cid {self.cluster_id}")
         write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
                              "floating_ip": self.configurations[0]["floating_ip"],
                              "state": "running",

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -598,10 +598,10 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
         self.log.log(42, f"Cluster {self.cluster_id} with master {self.master_ip} up and running!")
         self.log.log(42, f"SSH: ssh -i '{KEY_FOLDER}{self.key_name}' {self.ssh_user}@{ssh_ip}"
                          f"{f' -p {port}' if gateway else ''}")
-        self.log.log(42, f"Terminate cluster: bibigrid.sh terminate -i '{self.config_path}' -cid {self.cluster_id}")
-        self.log.log(42, f"Detailed cluster info: bibigrid.sh list -i '{self.config_path}' -cid {self.cluster_id}")
+        self.log.log(42, f"Terminate cluster: bibigrid terminate -i '{self.config_path}' -cid {self.cluster_id}")
+        self.log.log(42, f"Detailed cluster info: bibigrid list -i '{self.config_path}' -cid {self.cluster_id}")
         if self.configurations[0].get("ide"):
-            self.log.log(42, f"IDE Port Forwarding: bibigrid.sh ide -i '{self.config_path}' -cid {self.cluster_id}")
+            self.log.log(42, f"IDE Port Forwarding: bibigrid ide -i '{self.config_path}' -cid {self.cluster_id}")
         write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
                              "floating_ip": self.configurations[0]["floating_ip"],
                              "state": "running",


### PR DESCRIPTION
Now that we use packages, bibigrid.sh is no longer necessary but using `bibigrid` is enough. This is confusing and should be hotfixed. Doesn't change any technical part of the execution but only prints and documentation.