### PR TITLE
Fixed mounting order, Removed deprecated code

### DIFF
--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-server.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-server.yaml
@@ -6,13 +6,3 @@
     opts: bind,auto
     state: mounted
   when: flavor.ephemeral > 0
-
-- name: Mount disks
-  mount:
-    path: "{{ item.dst }}"
-    src: "{{ item.src }}"
-    fstype: ext4
-    state: mounted
-  with_items:
-    - "{{ master.disks }}"
-  when: master.disks is defined

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk.yaml
@@ -34,6 +34,18 @@
     dest: '/home/{{ ansible_distribution | lower }}/vol'
     state: link
 
+- name: Handle Ephemeral For Server
+  include_tasks: 020-disk-server.yaml
+  when: "'master' in group_names"
+  tags:
+    - "disk"
+
+- name: Handle Ephemeral For Worker
+  include_tasks: 020-disk-worker.yaml
+  when: "'master' not in group_names"
+  tags:
+    - "disk"
+
 - name: Automount
   when: volumes is defined
   include_tasks: 020-disk-automount.yaml

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/main.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/main.yaml
@@ -112,16 +112,6 @@
   import_tasks: 020-disk.yaml
   tags:
     - "disk"
-- name: Generate server directory structure available on all hosts
-  import_tasks: 020-disk-server.yaml
-  when: "'master' in group_names"
-  tags:
-    - "disk"
-- name: Generate worker directory structure available on all hosts
-  import_tasks: 020-disk-worker.yaml
-  when: "'master' not in group_names"
-  tags:
-    - "disk"
 
 - name: Setup NFS
   when:


### PR DESCRIPTION
The former order apparently caused issues with SimpleVM. I was not able to reproduce this but the order:

- mount /vol/spool
- mount /vol/

makes it reasonable that /vol/spool gets overshadowed. The new order:

- mount /vol/
- mount /vol/spool

avoids this issue.

At the same time old code in disk-server has been removed that was only executed when a variable has been set that we no longer used. That code was part of the old disk logic replaced by the new volume logic.

closes #682 