### PR TITLE
Update CLUSTER_UUID_ALPHABET to include lowercase l

### DIFF
--- a/bibigrid/core/utility/id_generation.py
+++ b/bibigrid/core/utility/id_generation.py
@@ -7,7 +7,7 @@ import shortuuid
 from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER, VPNGTW_IDENTIFIER, WORKER_IDENTIFIER
 
 MAX_ID_LENGTH = 15
-CLUSTER_UUID_ALPHABET = '0123456789abcdefghijkmnopqrstuvwxyz'
+CLUSTER_UUID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
 
 
 def generate_cluster_id():


### PR DESCRIPTION
Not sure if there is a specific reason why the letter 'l' is missing or its just a typo.
In case there is, could you explain the reasoning?