### PR TITLE
feat(Logging):added timestamps to uvicorn logging

### DIFF
--- a/bibigrid/core/startup_rest.py
+++ b/bibigrid/core/startup_rest.py
@@ -54,6 +54,8 @@ LOG.setLevel(logging.DEBUG)
 
 #Uvicorn Logging
 LOGGING_CONFIG["formatters"]["default"]["fmt"] = LOG_FORMAT
+LOGGING_CONFIG["formatters"]["access"]["fmt"] = LOG_FORMAT
+
 
 def tail(file_path, lines):
     return subprocess.check_output(['tail', '-n', str(lines), file_path], universal_newlines=True)

--- a/bibigrid/core/startup_rest.py
+++ b/bibigrid/core/startup_rest.py
@@ -12,6 +12,8 @@ import threading
 from typing import Union
 
 import uvicorn
+from uvicorn.config import LOGGING_CONFIG
+
 import yaml
 from fastapi import FastAPI, status, Request
 from fastapi.exceptions import RequestValidationError
@@ -50,6 +52,8 @@ LOG.addHandler(file_handler)
 logging.addLevelName(42, "PRINT")
 LOG.setLevel(logging.DEBUG)
 
+#Uvicorn Logging
+LOGGING_CONFIG["formatters"]["default"]["fmt"] = LOG_FORMAT
 
 def tail(file_path, lines):
     return subprocess.check_output(['tail', '-n', str(lines), file_path], universal_newlines=True)


### PR DESCRIPTION
Added Uvicorn logging configuration to enhance logging format.

Old:
INFO:     172.18.0.6:59830 - "GET /bibigrid/state/kkzd9om3e6otye3 HTTP/1.1" 200 OK


New:

2026-03-11 13:56:58,403 [INFO] 172.18.0.16:57368 - "GET /bibigrid/requirements HTTP/1.1" 200