### PR TITLE
Adds Default Value For Role.tags

### DIFF
--- a/bibigrid/core/utility/validate_configuration.py
+++ b/bibigrid/core/utility/validate_configuration.py
@@ -229,7 +229,7 @@ class ValidateConfiguration:
         for security_group_name in security_groups:
             security_group = provider.get_security_group(security_group_name)
             if not security_group:
-                self.log.warning(f"Couldn't find security group {security_group} on "
+                self.log.warning(f"Couldn't find security group {security_group_name} on "
                                  f"cloud {provider.cloud_specification['identifier']}")
                 success = False
             else:

--- a/bibigrid/models/configuration.py
+++ b/bibigrid/models/configuration.py
@@ -28,7 +28,7 @@ class Role(StrictModel):
     Ansible Role
     """
     name: str
-    tags: Optional[List[str]]
+    tags: Optional[List[str]] = None
 
 
 class UserRole(StrictModel):


### PR DESCRIPTION
Currently, in the UserRoles functionality Role.tags have no default value. Due to strict checking this forces users to always set the tags even when not used. This PR sets a default value fixing the issue.

Closes #716