### PR TITLE
Improves Nvidia and Cuda out-of-the-box setup

### DIFF
--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml
@@ -81,6 +81,27 @@
       args:
         creates: /usr/bin/nvidia-smi
       notify: Nvidia drivers installed
+    - name: Install cuda toolkit
+      apt:
+        name: nvidia-cuda-toolkit
+        state: present
+        update_cache: true
+    # Container Toolkit
+    - name: add GPG key for nvidia-container-runtime
+      apt_key:
+        url: https://nvidia.github.io/libnvidia-container/gpgkey
+        keyring: /etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg
+        state: "present"
+    - name: add nvidia-container-runtime repository to apt
+      apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /"
+        state: present
+        filename: nvidia-container-toolkit
+        update_cache: true
+    - name: install nvidia-contaier-toolkit
+      apt:
+        name: nvidia-container-toolkit
+        state: present
 
 - name: Flush handlers
   meta: flush_handlers

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml
@@ -87,18 +87,18 @@
         state: present
         update_cache: true
     # Container Toolkit
-    - name: add GPG key for nvidia-container-runtime
+    - name: Add GPG Key For nvidia-container-runtime
       apt_key:
         url: https://nvidia.github.io/libnvidia-container/gpgkey
         keyring: /etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg
         state: "present"
-    - name: add nvidia-container-runtime repository to apt
+    - name: Add nvidia-container-runtime Repository to Apt
       apt_repository:
         repo: "deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /"
         state: present
         filename: nvidia-container-toolkit
         update_cache: true
-    - name: install nvidia-contaier-toolkit
+    - name: Install nvidia-contaier-toolkit
       apt:
         name: nvidia-container-toolkit
         state: present

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
@@ -1,37 +1,40 @@
-- name: Add Docker's official GPG key
-  ansible.builtin.apt_key:
+- name: Ensure Keyring Directory
+  file:
+    group: root
+    owner: root
+    path: "/etc/apt/keyrings"
+    state: "directory"
+    mode: "755"
+
+- name: Add Docker's Official GPG Key
+  get_url:
     url: https://download.docker.com/linux/ubuntu/gpg
-    keyring: /etc/apt/keyrings/docker.gpg
+    group: root
+    owner: root
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "644"
+
+- name: Add docker repository to apt
+  apt_repository:
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
-
-
-- name: Add Docker repository
-  ansible.builtin.apt_repository:
-    repo: >-
-      deb [arch={{ arch_mapping[ansible_architecture] | default(ansible_architecture) }}
-      signed-by=/etc/apt/keyrings/docker.gpg]
-      https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable
     filename: docker
-    state: present
-  vars:
-    arch_mapping:
-      x86_64: amd64
+    update_cache: true
 
 - name: Install Docker
   apt:
     name:
-      - docker.io
-      - python3-docker
-      - docker-compose
-      - docker-compose-plugin
-    state: present
-  tags: install
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+
 
 - name: Configure Docker
   copy:
     content: |-
       {
-         "mtu":{{ ansible_default_ipv4.mtu }}
+         "mtu": {{ ansible_default_ipv4.mtu }}
       }
     dest: /etc/docker/daemon.json
     owner: root
@@ -39,14 +42,19 @@
     mode: "0o644"
   notify: Docker
 
-- name: Create docker group and change GID
+- name: Create Docker Group and Change GID
   group:
     name: docker
     gid: 1234
     state: present
 
-- name: Append ubuntu user to group docker
+- name: Append Ubuntu User To Group Docker
   user:
     name: ubuntu
     append: true
     groups: docker
+
+- name: configure docker with nvidia-container-toolkit
+  when: flavor.gres is defined
+  shell: nvidia-ctk runtime configure --runtime=docker
+  notify: Docker

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
@@ -54,7 +54,7 @@
     append: true
     groups: docker
 
-- name: configure docker with nvidia-container-toolkit
+- name: Configure docker with nvidia-container-toolkit
   when: flavor.gres is defined
-  shell: nvidia-ctk runtime configure --runtime=docker
+  command: nvidia-ctk runtime configure --runtime=docker
   notify: Docker

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/030-docker.yaml
@@ -57,4 +57,5 @@
 - name: Configure docker with nvidia-container-toolkit
   when: flavor.gres is defined
   command: nvidia-ctk runtime configure --runtime=docker
+  changed_when: false
   notify: Docker

--- a/documentation/markdown/features/gres.md
+++ b/documentation/markdown/features/gres.md
@@ -1,9 +1,12 @@
 # GPU Nodes (GRES)
 
 Currently, BiBiGrid can only handle GPU nodes with NVIDIA graphic cards. 
-BiBiGrid will [install NVIDIA drivers](bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml) 
-and set up the [gres.conf](https://slurm.schedmd.com/gres.conf.html) files and adjust 
+BiBiGrid will [install NVIDIA drivers](bibigrid/resources/playbook/roles/bibigrid/tasks/001-apt.yaml), 
+set up the [gres.conf](https://slurm.schedmd.com/gres.conf.html) files and adjust 
 the [slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_Gres_1) accordingly.
+
+Additionally, `nvidia-cuda-toolkit` and `nvidia-container-runtime` are installed and configured nvidia-container-runtime 
+to use docker: `nvidia-ctk runtime configure --runtime=docker`.
 
 For this the gres information is stored in the group vars.
 


### PR DESCRIPTION
In addition to the nvidia drivers, BiBiGrid now also installs the cuda toolkit and the container toolkit. It also configures the toolkit to run with docker. This can be tested with "sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi" on a gpu node.

Running `sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi` on a gpu node verifies the correct setup of the container runtime.

Closes #719