### PR TITLE
Align with simplevm max ram reserve per node 4000 instead of 8000 and ubuntu user on mount points

### DIFF
--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -80,7 +80,7 @@ SlurmdLogFile=/var/log/slurm/slurmd.log
 {% set _ = node_groups.append(node.name) %}
 {# MiB to MB #}
 {% set mem = (node.flavor.ram * 0.98 - 150) | int %} # EXPERIMENTAL
-NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=1 RealMemory={{ mem }} MemSpecLimit={{ [mem//4 + 1000, 8000] | min }} State={{node.state }} {{"Features=" + (node.features | join(",")) + " " if node.features is defined}}{% if node.flavor.gres is defined and node.flavor.gres %}Gres={% for g in node.flavor.gres %}{{ g.name }}{% if g.type is defined and g.type %}:{{ g.type }}{% endif %}:{{ g.count }}{% if not loop.last %},{% endif %}{% endfor %} {% endif %}# {{ node.cloud_identifier }}# {{ node.cloud_identifier }}
+NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=1 RealMemory={{ mem }} MemSpecLimit={{ [mem//4 + 1000, 4000] | min }} State={{node.state }} {{"Features=" + (node.features | join(",")) + " " if node.features is defined}}{% if node.flavor.gres is defined and node.flavor.gres %}Gres={% for g in node.flavor.gres %}{{ g.name }}{% if g.type is defined and g.type %}:{{ g.type }}{% endif %}:{{ g.count }}{% if not loop.last %},{% endif %}{% endfor %} {% endif %}# {{ node.cloud_identifier }}# {{ node.cloud_identifier }}
 {% for partition in node.partitions %}
 {% if partition not in partitions %}
 {% set _ = partitions.update({partition: []}) %}

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-automount.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-automount.yaml
@@ -25,7 +25,7 @@
         path: "{{ item.mountPoint }}"
         state: directory
         mode: "0o755"
-        owner: root
+        owner: ubuntu
         group: '{{ ansible_distribution | lower }}'
 
     - name: Mount disks

--- a/bibigrid/resources/playbook/roles_user/resistance_nextflow/tasks/main.yml
+++ b/bibigrid/resources/playbook/roles_user/resistance_nextflow/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Unarchive ZIP file from GitHub repository
   unarchive:
     src: "https://github.com/deNBI/bibigrid_clum/raw/main/resources/Resistance_Nextflow.tar.xz"
-    dest: "/vol/spool/"
+    dest: "/vol/test/"
     remote_src: yes
 
 - name: Install Java JRE on Debian/Ubuntu
@@ -17,11 +17,11 @@
 - name: Get Nextflow
   shell: wget -qO- https://get.nextflow.io | bash
   args:
-    chdir: /vol/spool/
+    chdir: /vol/test/
 
 - name: Change file ownership, group and permissions
   file:
-    path: /vol/spool/nextflow
+    path: /vol/test/nextflow
     owner: ubuntu
     group: ubuntu
     mode: '0775'


### PR DESCRIPTION
In the past we set a relatively high minimum RAM for large machines of 8000 MiB. This PR reduces that number to 4000 MiB based on SimpleVM experience that more is not needed.

Also, mount points are now owned by Ubuntu instead of ROOT making it easier for users to execute nextflow on them.