### PR TITLE
Adds slurm_conf default_partition

### DIFF
--- a/bibigrid/models/configuration.py
+++ b/bibigrid/models/configuration.py
@@ -112,6 +112,7 @@ class SlurmConf(StrictModel):
     """
     Holds info on basic Slurm settings
     """
+    default_partition: str
     db: Optional[str] = "slurm"
     db_user: Optional[str] = "slurm"
     db_password: Optional[str] = "changeme"

--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -91,7 +91,10 @@ NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=
 {% endfor %}
 
 {% for key, value in partitions.items() %}
-PartitionName={{ key }} Nodes={{ value | join(",") }}{{ " Default=YES" if loop.last else ""}}
+PartitionName={{ key }} Nodes={{ value | join(",") }}{{ " Default=YES"
+   if (slurm_conf.default_partition is defined and key == slurm_conf.default_partition)
+   or (slurm_conf.default_partition is not defined and loop.last)
+   else "" }}
 {% endfor %}
 
 # JobSubmitPlugin


### PR DESCRIPTION
This PR adds the key:

```
slurmConf:
  default_partition: str
```

That you can set in order to not have `all` as the default partition. This is used by CloWM which has a `compute` partition and then other additional non default partitions.

Closes #724 