### PR TITLE
Mismatch for on demand scheduled gpu nodes

### DIFF
--- a/bibigrid/models/configuration.py
+++ b/bibigrid/models/configuration.py
@@ -112,6 +112,7 @@ class SlurmConf(StrictModel):
     """
     Holds info on basic Slurm settings
     """
+    default_partition: str
     db: Optional[str] = "slurm"
     db_user: Optional[str] = "slurm"
     db_password: Optional[str] = "changeme"

--- a/bibigrid/resources/bin/bibilog
+++ b/bibigrid/resources/bin/bibilog
@@ -8,7 +8,7 @@ fi
 if [ "$2" == "fail" ]; then
   fail_create="fail"
 else
-  fail_create="create"
+  fail_create="resume"
 fi
 
 LOG="/var/log/slurm/worker_logs/$fail_create/$err_out"

--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -91,7 +91,10 @@ NodeName={{ node.name }} SocketsPerBoard={{ node.flavor.vcpus }} CoresPerSocket=
 {% endfor %}
 
 {% for key, value in partitions.items() %}
-PartitionName={{ key }} Nodes={{ value | join(",") }}{{ " Default=YES" if loop.last else ""}}
+PartitionName={{ key }} Nodes={{ value | join(",") }}{{ " Default=YES"
+   if (slurm_conf.default_partition is defined and key == slurm_conf.default_partition)
+   or (slurm_conf.default_partition is not defined and loop.last)
+   else "" }}
 {% endfor %}
 
 # JobSubmitPlugin

--- a/bibigrid/resources/defaults/slurm/slurm.j2
+++ b/bibigrid/resources/defaults/slurm/slurm.j2
@@ -12,8 +12,7 @@ MpiDefault=none
 ProctrackType=proctrack/cgroup # linuxproc # changed for 23.11.0
 # ReturnToService=2
 SwitchType=switch/none
-TaskPlugin=task/none
-#TaskPlugin=task/cgroup
+TaskPlugin=task/cgroup
 JobAcctGatherType=jobacct_gather/linux
 
 # RESOURCES
@@ -65,6 +64,7 @@ SlurmctldDebug=debug # info
 SlurmctldLogFile=/var/log/slurm/slurmctld.log
 SlurmdDebug=info
 SlurmdLogFile=/var/log/slurm/slurmd.log
+DebugFlags=Gres
 
 # COMPUTE NODES
 # use_master_as_compute

--- a/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
+++ b/bibigrid/resources/playbook/roles/bibigrid/handlers/main.yml
@@ -34,6 +34,14 @@
     state: restarted
   when: "'master' in group_names"
 
+- name: Enable Slurmd
+  systemd:
+    name: "slurmd"
+    enabled: true
+    masked: false
+    state: started
+    daemon_reload: true
+
 - name: Slurmd
   systemd:
     name: slurmd

--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/042-slurm.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/042-slurm.yaml
@@ -108,12 +108,4 @@
     group: root
     mode: "0o444"
     force: true
-  when: flavor.gres is defined
-
-- name: Enable slurmd services
-  systemd:
-    name: "slurmd"
-    enabled: true
-    masked: false
-    state: started
-    daemon_reload: true
+  notify: Enable Slurmd

--- a/bibigrid/resources/playbook/roles/bibigrid/templates/slurm/gres.j2
+++ b/bibigrid/resources/playbook/roles/bibigrid/templates/slurm/gres.j2
@@ -1,8 +1,13 @@
 # GRES CONFIG
+{% for node_name in groups.master + groups.workers %}
+{% set node = hostvars[node_name] %}
 {% set ns = namespace(device_index=0) %}
-{% for gres in flavor.gres %}
+{% if node.flavor.gres is defined %}
+{% for gres in node.flavor.gres %}
 {% for i in range(gres.count | int) %}
-Name={{ gres.name }} Type={{ gres.type }} File=/dev/nvidia{{ ns.device_index }}
+NodeName={{ node.name }} Name={{ gres.name }} Type={{ gres.type }} File=/dev/nvidia{{ ns.device_index }}
 {% set ns.device_index = ns.device_index + 1 %}
 {% endfor %}
+{% endfor %}
+{% endif %}
 {% endfor %}

--- a/bibigrid/resources/playbook/roles/bibigrid/templates/slurm/gres_old_unused.j2
+++ b/bibigrid/resources/playbook/roles/bibigrid/templates/slurm/gres_old_unused.j2
@@ -1,0 +1,8 @@
+# GRES CONFIG
+{% set ns = namespace(device_index=0) %}
+{% for gres in flavor.gres %}
+{% for i in range(gres.count | int) %}
+Name={{ gres.name }} Type={{ gres.type }} File=/dev/nvidia{{ ns.device_index }}
+{% set ns.device_index = ns.device_index + 1 %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This PR adds that all nodes contain complete gres.conf which include nodenames to assign resources to nodes. Without it the issue #726 occurs.