### PR TITLE
Feature/increase worker count

### DIFF
--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -661,6 +661,23 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             self.configurations[0]["private_v4"] = server["private_v4"]
             self.configurations[0]["floating_ip"] = master_ip
             self.configurations[0]["volumes"] = server["volumes"]
+
+            # Without this, common_configuration_yaml's default slurmConf (see ansible_configurator.SLURM_CONF)
+            # would hand out a freshly random munge_key on every single grow() run, which then gets deployed to
+            # and restarts munge on the master and every already-running worker touched by this ansible run -
+            # rotating the cluster's munge key out from under anything (e.g. an external client) that still
+            # trusts the old one. Reusing the key already on the master keeps it stable across grows.
+            ssh_data = {"floating_ip": master_ip, "private_key": used_private_key, "username": ssh_user,
+                       "gateway": self.configurations[0].get("gateway", {}), "timeout": self.ssh_timeout,
+                       "sock5_proxy": self.configurations[0].get("sock5_proxy")}
+            existing_munge_key = ssh_handler.read_remote_file(ssh_data, "/etc/munge/munge.key", self.log)
+            if existing_munge_key:
+                self.configurations[0].setdefault("slurmConf", {})["munge_key"] = existing_munge_key
+            else:
+                raise ConfigurationException(
+                    "Unable to read the running cluster's existing munge key from the master. Aborting rather "
+                    "than risk deploying a new, mismatched one to the cluster.")
+
             self.prepare_configurations()
             self.create_defaults()
             # Unlike create(), don't call generate_security_groups() here: the cluster's security group

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -13,11 +13,13 @@ import paramiko
 import sympy
 from werkzeug.utils import secure_filename
 
-from bibigrid.core.actions.terminate import delete_keypairs, delete_local_keypairs, terminate, write_cluster_state
+from bibigrid.core.actions import list_clusters
+from bibigrid.core.actions.terminate import delete_keypairs, delete_local_keypairs, terminate, terminate_server, \
+    write_cluster_state
 from bibigrid.core.utility import ansible_configurator
 from bibigrid.core.utility import id_generation
 from bibigrid.core.utility import image_selection
-from bibigrid.core.utility.handler import ssh_handler
+from bibigrid.core.utility.handler import cluster_ssh_handler, ssh_handler
 from bibigrid.core.utility.paths import ansible_resources_path as a_rp
 from bibigrid.core.utility.paths.basic_path import CLUSTER_INFO_FOLDER, KEY_FOLDER
 from bibigrid.core.utility.statics.create_statics import AC_NAME, KEY_NAME, DEFAULT_SECURITY_GROUP_NAME, \
@@ -518,9 +520,13 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
     def create(self):  # pylint: disable=too-many-branches,too-many-statements
         """
         Creates cluster and logs helpful cluster-info afterwards.
+        If a cluster with this cluster_id is already running, grows it instead (see grow()).
         If debug is set True it offers termination after starting the cluster.
         @return: exit_state
         """
+        cluster_dict = list_clusters.dict_clusters(self.providers, self.log)
+        if cluster_dict.get(self.cluster_id, {}).get("master"):
+            return self.grow(cluster_dict[self.cluster_id])
         try:
             for folder in [a_rp.VARS_FOLDER, a_rp.GROUP_VARS_FOLDER, a_rp.HOST_VARS_FOLDER]:
                 if not os.path.isdir(folder):
@@ -578,6 +584,136 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
                              "floating_ip": self.configurations[0].get("floating_ip"),
                              "state": "failed",
                              "message": "Cluster creation failed. Terminated remains."})
+        return 1
+
+    def compute_worker_diff(self, cluster):
+        """
+        Walks configurations/workerInstances the same way ansible_configurator and
+        start_start_server_threads do (one running index across all groups, in config order) to figure out
+        which worker slots are new compared to what's actually running.
+        Only a pure, tail-safe append (growing an existing group's count, or adding nothing) is considered
+        safe. Reordering/inserting/removing worker groups, shrinking a count, or flipping onDemand for an
+        already-running worker's slot all raise ConfigurationException before anything is created, because
+        BiBiGrid's worker naming recomputes indices from scratch on every run and doesn't otherwise notice
+        that an already-running instance's expected name changed.
+        @param cluster: this cluster_id's entry from list_clusters.dict_clusters (has a "workers" list)
+        @return: list of (worker, index, configuration, provider) tuples to start, in index order
+        """
+        slots = {}  # index -> (worker, onDemand, configuration, provider)
+        index = 0
+        for configuration, provider in zip(self.configurations, self.providers):
+            for worker in configuration.get("workerInstances", []):
+                for _ in range(int(worker.get("count", 1))):
+                    slots[index] = (worker, worker.get("onDemand", True), configuration, provider)
+                    index += 1
+
+        desired_names_by_index = {i: WORKER_IDENTIFIER(cluster_id=self.cluster_id, additional=i) for i in slots}
+        desired_names = set(desired_names_by_index.values())
+        actual_names = {worker["name"] for worker in cluster.get("workers", [])}
+
+        unmatched = actual_names - desired_names
+        if unmatched:
+            raise ConfigurationException(
+                f"Existing worker(s) {sorted(unmatched)} no longer match this configuration's expected worker "
+                "names. Reordering, inserting, or shrinking workerInstances groups on a running cluster isn't "
+                "supported - only appending to an existing group's count is.")
+
+        to_create = []
+        for i, name in desired_names_by_index.items():
+            worker, on_demand, configuration, provider = slots[i]
+            if name in actual_names:
+                if on_demand:
+                    raise ConfigurationException(
+                        f"Worker {name} is already running but its group is now marked onDemand in the "
+                        "configuration. Changing onDemand for an already-running worker isn't supported.")
+                continue
+            if not on_demand:
+                to_create.append((worker, i, configuration, provider))
+        return to_create
+
+    def grow(self, cluster):  # pylint: disable=too-many-branches
+        """
+        Adds newly configured static (onDemand: False) workers to an already running cluster with this
+        cluster_id, leaving the existing master, security groups, keypair and already-running workers
+        untouched. onDemand worker groups need no new instance here - widening their group_vars/slurm.conf
+        range (done below via upload_data) is enough for SLURM's own elastic scheduler to boot them later.
+        On any failure, only rolls back the workers grow() itself created in this run - never the whole
+        cluster (unlike create(), which is safe to fully terminate on failure since nothing else depends on
+        a half-created cluster yet).
+        @param cluster: this cluster_id's entry from list_clusters.dict_clusters (must have a "master")
+        @return: exit_state
+        """
+        self.log.log(42, f"Cluster {self.cluster_id} is already running. Growing it instead of recreating it.")
+        new_worker_names = []
+        try:
+            if len(self.providers) > 1:
+                raise ConfigurationException(
+                    "Growing a multi-provider (multi-cloud/vpngtw) cluster isn't supported yet.")
+            master_ip, ssh_user, used_private_key = cluster_ssh_handler.get_ssh_connection_info(
+                self.cluster_id, self.providers[0], self.configurations[0], self.log)
+            if not (master_ip and ssh_user and used_private_key):
+                raise ConfigurationException(
+                    "Unable to determine master_ip, ssh_user or private key of the running cluster. Aborting.")
+            server = self.providers[0].get_server(MASTER_IDENTIFIER(cluster_id=self.cluster_id))
+            if not server:
+                raise ConfigurationException(f"Master of cluster {self.cluster_id} not found. Aborting.")
+            self.master_ip = master_ip
+            self.configurations[0]["private_v4"] = server["private_v4"]
+            self.configurations[0]["floating_ip"] = master_ip
+            self.configurations[0]["volumes"] = server["volumes"]
+            self.prepare_configurations()
+            self.create_defaults()
+
+            to_create = self.compute_worker_diff(cluster)
+            for worker, index, configuration, provider in to_create:
+                self.start_worker(worker, index, configuration, provider)
+                new_worker_names.append(WORKER_IDENTIFIER(cluster_id=self.cluster_id, additional=index))
+
+            self.upload_data(used_private_key, clean_playbook=True)
+            if new_worker_names:
+                message = f"Successfully grew cluster {self.cluster_id}. Added workers: {new_worker_names}"
+            else:
+                message = (f"Cluster {self.cluster_id}'s on-demand worker capacity was updated. No new "
+                          "instances were started; SLURM will boot them on demand as needed.")
+            self.log.log(42, message)
+            write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
+                                 "floating_ip": self.master_ip, "state": "running", "message": message})
+        except exceptions.ConnectionException:
+            self.log.error(traceback.format_exc())
+            self.log.error("Connection couldn't be established. Check Provider connection.")
+        except paramiko.ssh_exception.NoValidConnectionsError:
+            self.log.error(traceback.format_exc())
+            self.log.error("SSH connection couldn't be established. Check keypair.")
+        except KeyError as exc:
+            self.log.error(traceback.format_exc())
+            self.log.error(
+                f"Tried to access dictionary key {str(exc)}, but couldn't. Please check your configurations.")
+        except FileNotFoundError as exc:
+            self.log.error(traceback.format_exc())
+            self.log.error(f"Tried to access resource files but couldn't. No such file or directory: {str(exc)}")
+        except TimeoutError as exc:
+            self.log.error(traceback.format_exc())
+            self.log.error(f"Timeout while connecting to master: {str(exc)}")
+        except ExecutionException as exc:
+            self.log.error(traceback.format_exc())
+            self.log.error(f"Execution of cmd on remote host fails: {str(exc)}")
+        except ConfigurationException as exc:
+            self.log.error(traceback.format_exc())
+            self.log.error(f"Configuration invalid: {str(exc)}")
+        except Exception as exc:  # pylint: disable=broad-except
+            self.log.error(traceback.format_exc())
+            self.log.error(f"Unexpected error: '{str(exc)}' ({type(exc)}) Contact a developer!)")
+        else:
+            return 0  # will be called if no exception occurred
+        # unlike create()'s failure path, never terminate the whole (pre-existing) cluster here - only clean
+        # up the workers this grow() run itself started.
+        for name in new_worker_names:
+            server = self.providers[0].get_server(name)
+            if server:
+                terminate_server(self.providers[0], server, self.log)
+        write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
+                             "floating_ip": self.master_ip, "state": "failed",
+                             "message": "Cluster growth failed. Existing infrastructure left untouched."})
         return 1
 
     def log_cluster_start_info(self):

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -663,6 +663,14 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
             self.configurations[0]["volumes"] = server["volumes"]
             self.prepare_configurations()
             self.create_defaults()
+            # Unlike create(), don't call generate_security_groups() here: the cluster's security group
+            # already exists and that call would (re-)create it, duplicating both the group and its rules.
+            # The group name is deterministic from cluster_id, so it can just be reattached.
+            configuration = self.configurations[0]
+            if not configuration.get("securityGroups"):
+                configuration["securityGroups"] = [self.default_security_group_name]
+            else:
+                configuration["securityGroups"] = [self.default_security_group_name] + configuration["securityGroups"]
 
             to_create = self.compute_worker_diff(cluster)
             for worker, index, configuration, provider in to_create:

--- a/bibigrid/core/actions/create.py
+++ b/bibigrid/core/actions/create.py
@@ -13,13 +13,11 @@ import paramiko
 import sympy
 from werkzeug.utils import secure_filename
 
-from bibigrid.core.actions import list_clusters
-from bibigrid.core.actions.terminate import delete_keypairs, delete_local_keypairs, terminate, terminate_server, \
-    write_cluster_state
+from bibigrid.core.actions.terminate import delete_keypairs, delete_local_keypairs, terminate, write_cluster_state
 from bibigrid.core.utility import ansible_configurator
 from bibigrid.core.utility import id_generation
 from bibigrid.core.utility import image_selection
-from bibigrid.core.utility.handler import cluster_ssh_handler, ssh_handler
+from bibigrid.core.utility.handler import ssh_handler
 from bibigrid.core.utility.paths import ansible_resources_path as a_rp
 from bibigrid.core.utility.paths.basic_path import CLUSTER_INFO_FOLDER, KEY_FOLDER
 from bibigrid.core.utility.statics.create_statics import AC_NAME, KEY_NAME, DEFAULT_SECURITY_GROUP_NAME, \
@@ -520,13 +518,9 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
     def create(self):  # pylint: disable=too-many-branches,too-many-statements
         """
         Creates cluster and logs helpful cluster-info afterwards.
-        If a cluster with this cluster_id is already running, grows it instead (see grow()).
         If debug is set True it offers termination after starting the cluster.
         @return: exit_state
         """
-        cluster_dict = list_clusters.dict_clusters(self.providers, self.log)
-        if cluster_dict.get(self.cluster_id, {}).get("master"):
-            return self.grow(cluster_dict[self.cluster_id])
         try:
             for folder in [a_rp.VARS_FOLDER, a_rp.GROUP_VARS_FOLDER, a_rp.HOST_VARS_FOLDER]:
                 if not os.path.isdir(folder):
@@ -584,161 +578,6 @@ class Create:  # pylint: disable=too-many-instance-attributes,too-many-arguments
                              "floating_ip": self.configurations[0].get("floating_ip"),
                              "state": "failed",
                              "message": "Cluster creation failed. Terminated remains."})
-        return 1
-
-    def compute_worker_diff(self, cluster):
-        """
-        Walks configurations/workerInstances the same way ansible_configurator and
-        start_start_server_threads do (one running index across all groups, in config order) to figure out
-        which worker slots are new compared to what's actually running.
-        Only a pure, tail-safe append (growing an existing group's count, or adding nothing) is considered
-        safe. Reordering/inserting/removing worker groups, shrinking a count, or flipping onDemand for an
-        already-running worker's slot all raise ConfigurationException before anything is created, because
-        BiBiGrid's worker naming recomputes indices from scratch on every run and doesn't otherwise notice
-        that an already-running instance's expected name changed.
-        @param cluster: this cluster_id's entry from list_clusters.dict_clusters (has a "workers" list)
-        @return: list of (worker, index, configuration, provider) tuples to start, in index order
-        """
-        slots = {}  # index -> (worker, onDemand, configuration, provider)
-        index = 0
-        for configuration, provider in zip(self.configurations, self.providers):
-            for worker in configuration.get("workerInstances", []):
-                for _ in range(int(worker.get("count", 1))):
-                    slots[index] = (worker, worker.get("onDemand", True), configuration, provider)
-                    index += 1
-
-        desired_names_by_index = {i: WORKER_IDENTIFIER(cluster_id=self.cluster_id, additional=i) for i in slots}
-        desired_names = set(desired_names_by_index.values())
-        actual_names = {worker["name"] for worker in cluster.get("workers", [])}
-
-        unmatched = actual_names - desired_names
-        if unmatched:
-            raise ConfigurationException(
-                f"Existing worker(s) {sorted(unmatched)} no longer match this configuration's expected worker "
-                "names. Reordering, inserting, or shrinking workerInstances groups on a running cluster isn't "
-                "supported - only appending to an existing group's count is.")
-
-        to_create = []
-        for i, name in desired_names_by_index.items():
-            worker, on_demand, configuration, provider = slots[i]
-            if name in actual_names:
-                if on_demand:
-                    raise ConfigurationException(
-                        f"Worker {name} is already running but its group is now marked onDemand in the "
-                        "configuration. Changing onDemand for an already-running worker isn't supported.")
-                continue
-            if not on_demand:
-                to_create.append((worker, i, configuration, provider))
-        return to_create
-
-    def grow(self, cluster):  # pylint: disable=too-many-branches
-        """
-        Adds newly configured static (onDemand: False) workers to an already running cluster with this
-        cluster_id, leaving the existing master, security groups, keypair and already-running workers
-        untouched. onDemand worker groups need no new instance here - widening their group_vars/slurm.conf
-        range (done below via upload_data) is enough for SLURM's own elastic scheduler to boot them later.
-        On any failure, only rolls back the workers grow() itself created in this run - never the whole
-        cluster (unlike create(), which is safe to fully terminate on failure since nothing else depends on
-        a half-created cluster yet).
-        @param cluster: this cluster_id's entry from list_clusters.dict_clusters (must have a "master")
-        @return: exit_state
-        """
-        self.log.log(42, f"Cluster {self.cluster_id} is already running. Growing it instead of recreating it.")
-        new_worker_names = []
-        try:
-            if len(self.providers) > 1:
-                raise ConfigurationException(
-                    "Growing a multi-provider (multi-cloud/vpngtw) cluster isn't supported yet.")
-            master_ip, ssh_user, used_private_key = cluster_ssh_handler.get_ssh_connection_info(
-                self.cluster_id, self.providers[0], self.configurations[0], self.log)
-            if not (master_ip and ssh_user and used_private_key):
-                raise ConfigurationException(
-                    "Unable to determine master_ip, ssh_user or private key of the running cluster. Aborting.")
-            server = self.providers[0].get_server(MASTER_IDENTIFIER(cluster_id=self.cluster_id))
-            if not server:
-                raise ConfigurationException(f"Master of cluster {self.cluster_id} not found. Aborting.")
-            self.master_ip = master_ip
-            self.configurations[0]["private_v4"] = server["private_v4"]
-            self.configurations[0]["floating_ip"] = master_ip
-            self.configurations[0]["volumes"] = server["volumes"]
-
-            # Without this, common_configuration_yaml's default slurmConf (see ansible_configurator.SLURM_CONF)
-            # would hand out a freshly random munge_key on every single grow() run, which then gets deployed to
-            # and restarts munge on the master and every already-running worker touched by this ansible run -
-            # rotating the cluster's munge key out from under anything (e.g. an external client) that still
-            # trusts the old one. Reusing the key already on the master keeps it stable across grows.
-            ssh_data = {"floating_ip": master_ip, "private_key": used_private_key, "username": ssh_user,
-                       "gateway": self.configurations[0].get("gateway", {}), "timeout": self.ssh_timeout,
-                       "sock5_proxy": self.configurations[0].get("sock5_proxy")}
-            existing_munge_key = ssh_handler.read_remote_file(ssh_data, "/etc/munge/munge.key", self.log)
-            if existing_munge_key:
-                self.configurations[0].setdefault("slurmConf", {})["munge_key"] = existing_munge_key
-            else:
-                raise ConfigurationException(
-                    "Unable to read the running cluster's existing munge key from the master. Aborting rather "
-                    "than risk deploying a new, mismatched one to the cluster.")
-
-            self.prepare_configurations()
-            self.create_defaults()
-            # Unlike create(), don't call generate_security_groups() here: the cluster's security group
-            # already exists and that call would (re-)create it, duplicating both the group and its rules.
-            # The group name is deterministic from cluster_id, so it can just be reattached.
-            configuration = self.configurations[0]
-            if not configuration.get("securityGroups"):
-                configuration["securityGroups"] = [self.default_security_group_name]
-            else:
-                configuration["securityGroups"] = [self.default_security_group_name] + configuration["securityGroups"]
-
-            to_create = self.compute_worker_diff(cluster)
-            for worker, index, configuration, provider in to_create:
-                self.start_worker(worker, index, configuration, provider)
-                new_worker_names.append(WORKER_IDENTIFIER(cluster_id=self.cluster_id, additional=index))
-
-            self.upload_data(used_private_key, clean_playbook=True)
-            if new_worker_names:
-                message = f"Successfully grew cluster {self.cluster_id}. Added workers: {new_worker_names}"
-            else:
-                message = (f"Cluster {self.cluster_id}'s on-demand worker capacity was updated. No new "
-                          "instances were started; SLURM will boot them on demand as needed.")
-            self.log.log(42, message)
-            write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
-                                 "floating_ip": self.master_ip, "state": "running", "message": message})
-        except exceptions.ConnectionException:
-            self.log.error(traceback.format_exc())
-            self.log.error("Connection couldn't be established. Check Provider connection.")
-        except paramiko.ssh_exception.NoValidConnectionsError:
-            self.log.error(traceback.format_exc())
-            self.log.error("SSH connection couldn't be established. Check keypair.")
-        except KeyError as exc:
-            self.log.error(traceback.format_exc())
-            self.log.error(
-                f"Tried to access dictionary key {str(exc)}, but couldn't. Please check your configurations.")
-        except FileNotFoundError as exc:
-            self.log.error(traceback.format_exc())
-            self.log.error(f"Tried to access resource files but couldn't. No such file or directory: {str(exc)}")
-        except TimeoutError as exc:
-            self.log.error(traceback.format_exc())
-            self.log.error(f"Timeout while connecting to master: {str(exc)}")
-        except ExecutionException as exc:
-            self.log.error(traceback.format_exc())
-            self.log.error(f"Execution of cmd on remote host fails: {str(exc)}")
-        except ConfigurationException as exc:
-            self.log.error(traceback.format_exc())
-            self.log.error(f"Configuration invalid: {str(exc)}")
-        except Exception as exc:  # pylint: disable=broad-except
-            self.log.error(traceback.format_exc())
-            self.log.error(f"Unexpected error: '{str(exc)}' ({type(exc)}) Contact a developer!)")
-        else:
-            return 0  # will be called if no exception occurred
-        # unlike create()'s failure path, never terminate the whole (pre-existing) cluster here - only clean
-        # up the workers this grow() run itself started.
-        for name in new_worker_names:
-            server = self.providers[0].get_server(name)
-            if server:
-                terminate_server(self.providers[0], server, self.log)
-        write_cluster_state({"cluster_id": self.cluster_id, "ssh_user": self.ssh_user,
-                             "floating_ip": self.master_ip, "state": "failed",
-                             "message": "Cluster growth failed. Existing infrastructure left untouched."})
         return 1
 
     def log_cluster_start_info(self):

--- a/bibigrid/core/actions/update.py
+++ b/bibigrid/core/actions/update.py
@@ -1,34 +1,161 @@
 """
-Module that contains methods to update the master playbook
+Module that contains methods to update an already running cluster.
 """
+import traceback
+
+import paramiko
 
 from bibigrid.core.actions.list_clusters import dict_clusters
-from bibigrid.core.utility.handler import cluster_ssh_handler
+from bibigrid.core.actions.terminate import terminate_server, write_cluster_state
+from bibigrid.core.utility.handler import cluster_ssh_handler, ssh_handler
+from bibigrid.core.utility.statics.create_statics import MASTER_IDENTIFIER, WORKER_IDENTIFIER
+from bibigrid.models import exceptions
+from bibigrid.models.exceptions import ConfigurationException, ExecutionException
 
 
-def update(creator, log):
-    log.info(f"Starting update for cluster {creator.cluster_id}...")
-    master_ip, ssh_user, used_private_key = cluster_ssh_handler.get_ssh_connection_info(creator.cluster_id,
-                                                                                        creator.providers[0],
-                                                                                        creator.configurations[0], log)
-    log.info(f"Trying to update {master_ip}@{ssh_user} with key {used_private_key}")
+def compute_worker_diff(creator, cluster):
+    """
+    Compares configured worker slots against actually running workers.
+    Only a tail-safe append (growing an existing group's count, or adding a new group) is allowed - anything
+    else raises ConfigurationException, since worker indices/names are recomputed from scratch every run and
+    a reorder/shrink/onDemand-flip would silently point at the wrong already-running instance.
+    @param creator: Create instance holding this cluster's configurations/providers/cluster_id
+    @param cluster: this cluster_id's entry from list_clusters.dict_clusters (has a "workers" list)
+    @return: list of (worker, index, configuration, provider) tuples to start, in index order
+    """
+    slots = {}  # index -> (worker, onDemand, configuration, provider)
+    index = 0
+    for configuration, provider in zip(creator.configurations, creator.providers):
+        for worker in configuration.get("workerInstances", []):
+            for _ in range(int(worker.get("count", 1))):
+                slots[index] = (worker, worker.get("onDemand", True), configuration, provider)
+                index += 1
+
+    desired_names_by_index = {i: WORKER_IDENTIFIER(cluster_id=creator.cluster_id, additional=i) for i in slots}
+    desired_names = set(desired_names_by_index.values())
+    actual_names = {worker["name"] for worker in cluster.get("workers", [])}
+
+    unmatched = actual_names - desired_names
+    if unmatched:
+        raise ConfigurationException(
+            f"Existing worker(s) {sorted(unmatched)} no longer match this configuration's expected worker "
+            "names. Reordering, inserting, or shrinking workerInstances groups on a running cluster isn't "
+            "supported - only appending to an existing group's count is.")
+
+    to_create = []
+    for i, name in desired_names_by_index.items():
+        worker, on_demand, configuration, provider = slots[i]
+        if name in actual_names:
+            if on_demand:
+                raise ConfigurationException(
+                    f"Worker {name} is already running but its group is now marked onDemand in the "
+                    "configuration. Changing onDemand for an already-running worker isn't supported.")
+            continue
+        if not on_demand:
+            to_create.append((worker, i, configuration, provider))
+    return to_create
+
+
+def update(creator, log):  # pylint: disable=too-many-branches
+    """
+    Updates an already running cluster with this cluster_id and starts any newly configured static
+    (onDemand: False) workers (see compute_worker_diff). On failure, only rolls back the workers this run
+    itself created, never the whole cluster.
+    @param creator: Create instance holding this cluster's configurations/providers/cluster_id
+    @param log:
+    @return: exit_state
+    """
+    log.log(42, f"Starting update for cluster {creator.cluster_id}...")
     cluster_dict = dict_clusters(creator.providers, log)
-    if cluster_dict[creator.cluster_id]["workers"]:
-        workers = [worker['name'] for worker in cluster_dict[creator.cluster_id]["workers"]]
-        log.warning(f"There are still workers up! {workers}")
+    cluster = cluster_dict.get(creator.cluster_id)
+    if not cluster or not cluster.get("master"):
+        log.warning(f"Cluster {creator.cluster_id} not found. Aborting.")
         return 1
-    if master_ip and ssh_user and used_private_key:
-        master = creator.MASTER_IDENTIFIER(cluster_id=creator.cluster_id)
-        server = creator.providers[0].get_server(master)
+
+    new_worker_names = []
+    try:
+        if len(creator.providers) > 1:
+            raise ConfigurationException(
+                "Updating a multi-provider (multi-cloud/vpngtw) cluster isn't supported yet.")
+        master_ip, ssh_user, used_private_key = cluster_ssh_handler.get_ssh_connection_info(
+            creator.cluster_id, creator.providers[0], creator.configurations[0], log)
+        if not (master_ip and ssh_user and used_private_key):
+            raise ConfigurationException(
+                "Unable to determine master_ip, ssh_user or private key of the running cluster. Aborting.")
+        server = creator.providers[0].get_server(MASTER_IDENTIFIER(cluster_id=creator.cluster_id))
+        if not server:
+            raise ConfigurationException(f"Master of cluster {creator.cluster_id} not found. Aborting.")
         creator.master_ip = master_ip
         creator.configurations[0]["private_v4"] = server["private_v4"]
         creator.configurations[0]["floating_ip"] = master_ip
-        # TODO Test Volumes
         creator.configurations[0]["volumes"] = server["volumes"]
+
+        # reuse the master's existing munge key - otherwise ansible_configurator's default would generate a
+        # fresh one and rotate munge out from under already-running nodes on every update
+        ssh_data = {"floating_ip": master_ip, "private_key": used_private_key, "username": ssh_user,
+                   "gateway": creator.configurations[0].get("gateway", {}), "timeout": creator.ssh_timeout,
+                   "sock5_proxy": creator.configurations[0].get("sock5_proxy")}
+        existing_munge_key = ssh_handler.read_remote_file(ssh_data, "/etc/munge/munge.key", log)
+        if existing_munge_key:
+            creator.configurations[0].setdefault("slurmConf", {})["munge_key"] = existing_munge_key
+        else:
+            raise ConfigurationException(
+                "Unable to read the running cluster's existing munge key from the master. Aborting rather "
+                "than risk deploying a new, mismatched one to the cluster.")
+
         creator.prepare_configurations()
-        log.log(42, f"Uploading data and executing BiBiGrid's Ansible playbook to {creator.cluster_id}")
+        creator.create_defaults()
+        # don't call creator.generate_security_groups(): the group already exists and that would duplicate it
+        configuration = creator.configurations[0]
+        if not configuration.get("securityGroups"):
+            configuration["securityGroups"] = [creator.default_security_group_name]
+        else:
+            configuration["securityGroups"] = [creator.default_security_group_name] + configuration["securityGroups"]
+
+        to_create = compute_worker_diff(creator, cluster)
+        for worker, index, configuration, provider in to_create:
+            creator.start_worker(worker, index, configuration, provider)
+            new_worker_names.append(WORKER_IDENTIFIER(cluster_id=creator.cluster_id, additional=index))
+
         creator.upload_data(used_private_key, clean_playbook=True)
-        log.log(42, f"Successfully updated cluster {creator.cluster_id}")
+        if new_worker_names:
+            message = f"Successfully updated cluster {creator.cluster_id}. Added workers: {new_worker_names}"
+        else:
+            message = f"Successfully updated cluster {creator.cluster_id}."
+        log.log(42, message)
+        write_cluster_state({"cluster_id": creator.cluster_id, "ssh_user": creator.ssh_user,
+                             "floating_ip": creator.master_ip, "state": "running", "message": message})
+    except exceptions.ConnectionException:
+        log.error(traceback.format_exc())
+        log.error("Connection couldn't be established. Check Provider connection.")
+    except paramiko.ssh_exception.NoValidConnectionsError:
+        log.error(traceback.format_exc())
+        log.error("SSH connection couldn't be established. Check keypair.")
+    except KeyError as exc:
+        log.error(traceback.format_exc())
+        log.error(f"Tried to access dictionary key {str(exc)}, but couldn't. Please check your configurations.")
+    except FileNotFoundError as exc:
+        log.error(traceback.format_exc())
+        log.error(f"Tried to access resource files but couldn't. No such file or directory: {str(exc)}")
+    except TimeoutError as exc:
+        log.error(traceback.format_exc())
+        log.error(f"Timeout while connecting to master: {str(exc)}")
+    except ExecutionException as exc:
+        log.error(traceback.format_exc())
+        log.error(f"Execution of cmd on remote host fails: {str(exc)}")
+    except ConfigurationException as exc:
+        log.error(traceback.format_exc())
+        log.error(f"Configuration invalid: {str(exc)}")
+    except Exception as exc:  # pylint: disable=broad-except
+        log.error(traceback.format_exc())
+        log.error(f"Unexpected error: '{str(exc)}' ({type(exc)}) Contact a developer!)")
+    else:
         return 0
-    log.warning("One or more among master_ip, ssh_user and used_private_key are none. Aborting...")
+    for name in new_worker_names:
+        server = creator.providers[0].get_server(name)
+        if server:
+            terminate_server(creator.providers[0], server, log)
+    write_cluster_state({"cluster_id": creator.cluster_id, "ssh_user": creator.ssh_user,
+                         "floating_ip": creator.master_ip, "state": "failed",
+                         "message": "Cluster update failed. Existing infrastructure left untouched."})
     return 1

--- a/bibigrid/core/startup.py
+++ b/bibigrid/core/startup.py
@@ -68,7 +68,7 @@ def check_cid(cluster_id):
         LOG.info("-cid %s is not a cid, but probably the master's ip. "
                  "Using the master ip instead of cid only works if a cluster key is in your systems default ssh key "
                  "location (~/.ssh/). Otherwise bibigrid can't identify the cluster key.")
-    if len(cluster_id) != id_generation.MAX_ID_LENGTH or not set(cluster_id).issubset(
+    if len(cluster_id) > id_generation.MAX_ID_LENGTH or not set(cluster_id).issubset(
             id_generation.CLUSTER_UUID_ALPHABET):
         LOG.warning(
             f"Cluster id doesn't fit length ({id_generation.MAX_ID_LENGTH}) or defined alphabet "

--- a/bibigrid/core/startup.py
+++ b/bibigrid/core/startup.py
@@ -58,12 +58,10 @@ def set_logger_verbosity(verbosity):
     LOG.debug(f"Logging verbosity set to {capped_verbosity}")
 
 
-def check_cid(cluster_id, configurations):
-    providers = provider_handler.get_providers(configurations, LOG)
-    if not id_generation.is_unique_cluster_id(cluster_id, providers):
-        msg = f"Cluster id ({cluster_id}) already exists"
-        LOG.error(msg)
-        raise RuntimeError(msg)
+def check_cid(cluster_id):
+    # Note: an existing cluster_id is intentionally allowed through here (not an error) - `create` will
+    # grow that cluster instead of recreating it (see Create.grow()), which also validates that the new
+    # configuration is a safe, tail-only append before touching anything.
     if "-" in cluster_id:
         new_cid = cluster_id.split("-")[-1]
         LOG.info("-cid %s is not a cid, but probably the entire master name. Using '%s' as "
@@ -186,7 +184,7 @@ def main(verbose, debug, config_input, default_config_input, enforced_config_inp
         sys.exit(1)
 
     if cluster_id:
-        cluster_id = check_cid(cluster_id, configurations)
+        cluster_id = check_cid(cluster_id)
 
     configurations = configuration_handler.merge_configurations(
         user_config=configurations,

--- a/bibigrid/core/startup.py
+++ b/bibigrid/core/startup.py
@@ -58,7 +58,12 @@ def set_logger_verbosity(verbosity):
     LOG.debug(f"Logging verbosity set to {capped_verbosity}")
 
 
-def check_cid(cluster_id):
+def check_cid(cluster_id, configurations):
+    providers = provider_handler.get_providers(configurations, LOG)
+    if not id_generation.is_unique_cluster_id(cluster_id, providers):
+        msg = f"Cluster id ({cluster_id}) already exists"
+        LOG.error(msg)
+        raise RuntimeError(msg)
     if "-" in cluster_id:
         new_cid = cluster_id.split("-")[-1]
         LOG.info("-cid %s is not a cid, but probably the entire master name. Using '%s' as "
@@ -175,13 +180,13 @@ def main(verbose, debug, config_input, default_config_input, enforced_config_inp
     default_config_input = expand_path(default_config_input)
     enforced_config_input = expand_path(enforced_config_input)
 
-    if cluster_id:
-        cluster_id = check_cid(cluster_id)
-
     configurations = configuration_handler.read_configuration(LOG, config_input)
 
     if not configurations:
         sys.exit(1)
+
+    if cluster_id:
+        cluster_id = check_cid(cluster_id, configurations)
 
     configurations = configuration_handler.merge_configurations(
         user_config=configurations,

--- a/bibigrid/core/startup.py
+++ b/bibigrid/core/startup.py
@@ -58,16 +58,13 @@ def set_logger_verbosity(verbosity):
     LOG.debug(f"Logging verbosity set to {capped_verbosity}")
 
 
-def check_cid(cluster_id):
-    # Note: an existing cluster_id is intentionally allowed through here (not an error) - `create` will
-    # grow that cluster instead of recreating it (see Create.grow()), which also validates that the new
-    # configuration is a safe, tail-only append before touching anything.
+def check_cid(cluster_id, configurations, action):
     if "-" in cluster_id:
         new_cid = cluster_id.split("-")[-1]
         LOG.info("-cid %s is not a cid, but probably the entire master name. Using '%s' as "
                  "cid instead.", cluster_id, new_cid)
-        return new_cid
-    if "." in cluster_id:
+        cluster_id = new_cid
+    elif "." in cluster_id:
         LOG.info("-cid %s is not a cid, but probably the master's ip. "
                  "Using the master ip instead of cid only works if a cluster key is in your systems default ssh key "
                  "location (~/.ssh/). Otherwise bibigrid can't identify the cluster key.")
@@ -78,6 +75,16 @@ def check_cid(cluster_id):
             f"({id_generation.CLUSTER_UUID_ALPHABET}). Aborting.")
         raise RuntimeError(f"Cluster id doesn't fit length ({id_generation.MAX_ID_LENGTH}) or defined alphabet "
                            f"({id_generation.CLUSTER_UUID_ALPHABET}). Aborting.")
+    if action == 'create':
+        providers = provider_handler.get_providers(configurations, LOG)
+        try:
+            if not id_generation.is_unique_cluster_id(cluster_id, providers):
+                msg = f"Cluster id ({cluster_id}) already exists. Use 'update' to modify a running cluster."
+                LOG.error(msg)
+                raise RuntimeError(msg)
+        finally:
+            for provider in providers:
+                provider.close()
     return cluster_id
 
 
@@ -184,7 +191,7 @@ def main(verbose, debug, config_input, default_config_input, enforced_config_inp
         sys.exit(1)
 
     if cluster_id:
-        cluster_id = check_cid(cluster_id)
+        cluster_id = check_cid(cluster_id, configurations, action)
 
     configurations = configuration_handler.merge_configurations(
         user_config=configurations,

--- a/bibigrid/core/startup_rest.py
+++ b/bibigrid/core/startup_rest.py
@@ -64,7 +64,7 @@ def setup(cluster_id, configurations_json=None):
     """
     if cluster_id:
         if cluster_id and (
-                len(cluster_id) != id_generation.MAX_ID_LENGTH or not set(cluster_id).issubset(
+                len(cluster_id) > id_generation.MAX_ID_LENGTH or not set(cluster_id).issubset(
             id_generation.CLUSTER_UUID_ALPHABET)):
             LOG.warning(f"Cluster id doesn't fit length ({id_generation.MAX_ID_LENGTH}) or defined alphabet "
                         f"({id_generation.CLUSTER_UUID_ALPHABET}). Aborting.")

--- a/bibigrid/core/startup_rest.py
+++ b/bibigrid/core/startup_rest.py
@@ -159,9 +159,10 @@ async def create_cluster(configurations_json: ConfigurationsModel, cluster_id: s
 
     try:
         providers = provider_handler.get_providers(configurations, log)
-        if not id_generation.is_unique_cluster_id(cluster_id=cluster_id, providers=providers):
-            return JSONResponse(content={"message": f"Cluster with cluster id {cluster_id} is already running."},
-                                status_code=400)
+        # Note: an existing, already-running cluster_id is intentionally allowed through here (not an
+        # error) - Create.create() will grow that cluster instead of recreating it (see Create.grow()),
+        # which also validates that the new configuration is a safe, tail-only append before touching
+        # anything.
         creator = create.Create(providers=providers, configurations=configurations, log=log,
                                 config_path=None, cluster_id=cluster_id)
         cluster_id = creator.cluster_id

--- a/bibigrid/core/startup_rest.py
+++ b/bibigrid/core/startup_rest.py
@@ -159,10 +159,9 @@ async def create_cluster(configurations_json: ConfigurationsModel, cluster_id: s
 
     try:
         providers = provider_handler.get_providers(configurations, log)
-        # Note: an existing, already-running cluster_id is intentionally allowed through here (not an
-        # error) - Create.create() will grow that cluster instead of recreating it (see Create.grow()),
-        # which also validates that the new configuration is a safe, tail-only append before touching
-        # anything.
+        if not id_generation.is_unique_cluster_id(cluster_id=cluster_id, providers=providers):
+            return JSONResponse(content={"message": f"Cluster with cluster id {cluster_id} is already running."},
+                                status_code=400)
         creator = create.Create(providers=providers, configurations=configurations, log=log,
                                 config_path=None, cluster_id=cluster_id)
         cluster_id = creator.cluster_id

--- a/bibigrid/core/utility/handler/ssh_handler.py
+++ b/bibigrid/core/utility/handler/ssh_handler.py
@@ -154,6 +154,33 @@ def is_active(client, paramiko_key, ssh_data, log):
                 raise ConnectionException(exc) from exc
 
 
+def read_remote_file(ssh_data, remote_path, log):
+    """
+    Reads a file on the remote as root (via sudo cat) and returns its content.
+    Used to read back already-deployed secrets (e.g. the munge key) instead of regenerating them.
+    @param ssh_data: dict containing floating_ip, private_key, username, gateway, timeout, sock5_proxy
+    @param remote_path: absolute path of the file on remote
+    @param log:
+    @return: file content (str) or None if the file couldn't be read
+    """
+    log.debug("Running read_remote_file")
+    paramiko_key = paramiko.ECDSAKey.from_private_key_file(ssh_data["private_key"])
+    with paramiko.SSHClient() as client:
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            is_active(client=client, paramiko_key=paramiko_key, ssh_data=ssh_data, log=log)
+        except ConnectionException as exc:
+            log.error(f"Couldn't connect to ip {ssh_data['gateway'] or ssh_data['floating_ip']} using private key "
+                      f"{ssh_data['private_key']}.")
+            raise exc
+        _, ssh_stdout, ssh_stderr = client.exec_command(f"sudo cat {remote_path}")
+        exit_status = ssh_stdout.channel.recv_exit_status()
+        if exit_status:
+            log.debug(f"Unable to read remote file {remote_path}: {ssh_stderr.read().decode().strip()}")
+            return None
+        return ssh_stdout.read().decode().strip()
+
+
 def line_buffered(f):
     """
     https://stackoverflow.com/questions/25260088/paramiko-with-continuous-stdout

--- a/documentation/markdown/features/CLI.md
+++ b/documentation/markdown/features/CLI.md
@@ -9,10 +9,11 @@ bibigrid.core.startup [OPTIONS] {create|terminate|list|check|ide|update}
 
 ## Action Argument
 - `check` Validates cluster configuration.
-- `create` Creates cluster.
+- `create` Creates cluster. Fails if the given cluster-id already belongs to a running cluster - use `update` instead.
 - `terminate` Terminates cluster. Needs option cluster-id
 - `list` Lists all running clusters. If option cluster-id is set, will list this cluster in detail only.
-- `update` Updates master's playbook. Needs option cluster-id, no job running and no workers powered up.
+- `update` Updates a running cluster's playbook/configuration and starts any newly configured static
+  (`onDemand: False`) workers. Needs option cluster-id.
 - `ide` Establishes a secured connection to Theia ide.
 
 ## Options

--- a/documentation/markdown/features/update.md
+++ b/documentation/markdown/features/update.md
@@ -3,6 +3,13 @@ This feature is experimental
 
 Update re-uploads the playbook, updates the configuration data and executes the playbook again.
 
+For `workerInstances`, update also compares the newly configured worker groups against what's actually
+running and starts any newly added static (`onDemand: False`) workers. Only appending to the end of a
+worker group's `count` (or adding a new group) is supported - reordering, inserting, shrinking a group,
+or flipping `onDemand` for an already-running worker is rejected before anything is touched, since
+BiBiGrid recomputes worker names/indices from scratch on every run and would otherwise lose track of
+already-running instances. Growing a multi-provider (multi-cloud/vpngtw) cluster isn't supported yet.
+
 Updating the configuration data does not allow for all kinds of updates, because some changes - 
 like attaching volumes, would need an undo process which is not implemented. That might come in a future version.
 Therefore, some keys mentioned below in [updatable](#updatable) have "(activate)" behind them.
@@ -14,7 +21,7 @@ Those keys should not be deactivated, but only activated in updates.
 - Ansible playbook
 
 
-- workerInstances
+- workerInstances (append-only, see above)
 - useMasterAsCompute
 - userRoles
 - cloudScheduling

--- a/tests/unit_tests/test_startup.py
+++ b/tests/unit_tests/test_startup.py
@@ -94,3 +94,44 @@ class TestStartup(TestCase):
         self.assertTrue(startup.run_action(action="ide", configurations=configurations, config_input="", cluster_id=21,
                                            debug=True) == 42)
         mock_ide.assert_called_with(21, provider_mock, {"test_key": "test_value"}, startup.LOG)
+
+    @patch('bibigrid.core.utility.id_generation.is_unique_cluster_id')
+    @patch('bibigrid.core.utility.handler.provider_handler.get_providers')
+    def test_check_cid_create_unique_passes_through(self, get_providers, mock_is_unique):
+        provider_mock = Mock()
+        provider_mock.close = Mock()
+        get_providers.return_value = [provider_mock]
+        mock_is_unique.return_value = True
+        self.assertEqual("abc123", startup.check_cid("abc123", configurations={}, action="create"))
+        provider_mock.close.assert_called_once()
+
+    @patch('bibigrid.core.utility.id_generation.is_unique_cluster_id')
+    @patch('bibigrid.core.utility.handler.provider_handler.get_providers')
+    def test_check_cid_create_duplicate_raises_and_still_closes_providers(self, get_providers, mock_is_unique):
+        provider_mock = Mock()
+        provider_mock.close = Mock()
+        get_providers.return_value = [provider_mock]
+        mock_is_unique.return_value = False
+        with self.assertRaises(RuntimeError):
+            startup.check_cid("abc123", configurations={}, action="create")
+        provider_mock.close.assert_called_once()
+
+    @patch('bibigrid.core.utility.id_generation.is_unique_cluster_id')
+    @patch('bibigrid.core.utility.handler.provider_handler.get_providers')
+    def test_check_cid_update_skips_uniqueness_check(self, get_providers, mock_is_unique):
+        self.assertEqual("abc123", startup.check_cid("abc123", configurations={}, action="update"))
+        get_providers.assert_not_called()
+        mock_is_unique.assert_not_called()
+
+    @patch('bibigrid.core.utility.id_generation.is_unique_cluster_id')
+    @patch('bibigrid.core.utility.handler.provider_handler.get_providers')
+    def test_check_cid_create_checks_uniqueness_of_normalized_cid(self, get_providers, mock_is_unique):
+        # regression: the master-name -> cid normalization must happen before the uniqueness check runs,
+        # otherwise "create -cid bibigrid-master-abc123" would check the wrong (unnormalized) value
+        provider_mock = Mock()
+        provider_mock.close = Mock()
+        get_providers.return_value = [provider_mock]
+        mock_is_unique.return_value = True
+        result = startup.check_cid("bibigrid-master-abc123", configurations={}, action="create")
+        self.assertEqual("abc123", result)
+        mock_is_unique.assert_called_once_with("abc123", [provider_mock])

--- a/tests/unit_tests/test_update.py
+++ b/tests/unit_tests/test_update.py
@@ -1,0 +1,223 @@
+"""
+Module to test update
+"""
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from bibigrid.core import startup
+from bibigrid.core.actions import create, update
+from bibigrid.models.exceptions import ConfigurationException, ExecutionException
+
+
+# pylint: disable=too-many-positional-arguments
+class TestUpdate(TestCase):
+    """
+    Class to test update and compute_worker_diff
+    """
+
+    @staticmethod
+    def _creator(configurations, providers=None):
+        provider = providers[0] if providers else MagicMock()
+        provider.list_servers.return_value = []
+        return create.Create(providers=providers or [provider], configurations=configurations, config_path="",
+                             log=startup.LOG, cluster_id="abc123")
+
+    def test_diff_pure_append_only_new_index_returned(self):
+        configurations = [{"workerInstances": [{"type": "t", "image": "i", "count": 4, "onDemand": False}]}]
+        creator = self._creator(configurations)
+        cluster = {"workers": [{"name": f"bibigrid-worker-abc123-{i}"} for i in range(3)]}
+        to_create = update.compute_worker_diff(creator, cluster)
+        self.assertEqual([3], [index for _, index, _, _ in to_create])
+
+    def test_diff_on_demand_group_needs_no_new_instance(self):
+        configurations = [{"workerInstances": [{"type": "t", "image": "i", "count": 2, "onDemand": True}]}]
+        creator = self._creator(configurations)
+        self.assertEqual([], update.compute_worker_diff(creator, {"workers": []}))
+
+    def test_diff_rejects_shrink_or_reorder(self):
+        configurations = [{"workerInstances": [{"type": "t", "image": "i", "count": 2, "onDemand": False}]}]
+        creator = self._creator(configurations)
+        # index 2 is running but the new config only expects indices 0 and 1
+        cluster = {"workers": [{"name": f"bibigrid-worker-abc123-{i}"} for i in range(3)]}
+        with self.assertRaises(ConfigurationException):
+            update.compute_worker_diff(creator, cluster)
+
+    def test_diff_rejects_on_demand_flip_of_running_worker(self):
+        configurations = [{"workerInstances": [{"type": "t", "image": "i", "count": 1, "onDemand": True}]}]
+        creator = self._creator(configurations)
+        cluster = {"workers": [{"name": "bibigrid-worker-abc123-0"}]}
+        with self.assertRaises(ConfigurationException):
+            update.compute_worker_diff(creator, cluster)
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "start_worker")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_happy_path_creates_only_the_delta(self, mock_ssh_info, mock_read_remote_file, mock_prepare,
+                                                       mock_defaults, mock_start_worker, mock_upload,
+                                                       mock_terminate_server, mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = "existing-munge-key"
+        provider.get_server.return_value = {"private_v4": "10.0.0.1", "volumes": []}
+        configuration = {"workerInstances": [{"type": "t", "image": "i", "count": 4, "onDemand": False}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"},
+                  "workers": [{"name": f"bibigrid-worker-abc123-{i}"} for i in range(3)]}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(0, update.update(creator, startup.LOG))
+        mock_start_worker.assert_called_once_with(configuration["workerInstances"][0], 3, configuration, provider)
+        mock_upload.assert_called_once_with("/tmp/key", clean_playbook=True)
+        mock_terminate_server.assert_not_called()
+        # regression: update() must populate securityGroups itself (start_worker requires it) but must not
+        # recreate the cluster's security group - that group already exists from the original create()
+        self.assertEqual(["default-abc123"], configuration["securityGroups"])
+        provider.create_security_group.assert_not_called()
+        # regression: update() must reuse the master's already-deployed munge key rather than letting
+        # ansible_configurator's SLURM_CONF default hand out (and redeploy) a fresh random one
+        self.assertEqual("existing-munge-key", configuration["slurmConf"]["munge_key"])
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "start_worker")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_preserves_user_configured_security_groups(self, mock_ssh_info, mock_read_remote_file,
+                                                               mock_prepare, mock_defaults, mock_start_worker,
+                                                               mock_upload, mock_terminate_server,
+                                                               mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = "existing-munge-key"
+        provider.get_server.return_value = {"private_v4": "10.0.0.1", "volumes": []}
+        configuration = {"securityGroups": ["extra-group"],
+                         "workerInstances": [{"type": "t", "image": "i", "count": 1, "onDemand": False}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"}, "workers": []}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(0, update.update(creator, startup.LOG))
+        self.assertEqual(["default-abc123", "extra-group"], configuration["securityGroups"])
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "start_worker")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_on_demand_only_starts_nothing_but_still_uploads(self, mock_ssh_info, mock_read_remote_file,
+                                                                     mock_prepare, mock_defaults, mock_start_worker,
+                                                                     mock_upload, mock_terminate_server,
+                                                                     mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = "existing-munge-key"
+        provider.get_server.return_value = {"private_v4": "10.0.0.1", "volumes": []}
+        configuration = {"workerInstances": [{"type": "t", "image": "i", "count": 2, "onDemand": True}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"}, "workers": []}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(0, update.update(creator, startup.LOG))
+        mock_start_worker.assert_not_called()
+        mock_upload.assert_called_once_with("/tmp/key", clean_playbook=True)
+        mock_terminate_server.assert_not_called()
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "start_worker")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_rejects_shrink_without_creating_or_terminating_anything(self, mock_ssh_info,
+                                                                            mock_read_remote_file, mock_prepare,
+                                                                            mock_defaults, mock_start_worker,
+                                                                            mock_upload, mock_terminate_server,
+                                                                            mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = "existing-munge-key"
+        provider.get_server.return_value = {"private_v4": "10.0.0.1", "volumes": []}
+        configuration = {"workerInstances": [{"type": "t", "image": "i", "count": 2, "onDemand": False}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"},
+                  "workers": [{"name": f"bibigrid-worker-abc123-{i}"} for i in range(3)]}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(1, update.update(creator, startup.LOG))
+        mock_start_worker.assert_not_called()
+        mock_upload.assert_not_called()
+        # an update failure must never fall back to the blanket, whole-cluster terminate() create() uses
+        mock_terminate_server.assert_not_called()
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    def test_update_rejects_multi_provider_clusters(self, mock_dict_clusters):
+        creator = self._creator([{"workerInstances": []}, {"workerInstances": []}],
+                                providers=[MagicMock(), MagicMock()])
+        mock_dict_clusters.return_value = {"abc123": {"master": {"name": "bibigrid-master-abc123"}, "workers": []}}
+        self.assertEqual(1, update.update(creator, startup.LOG))
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    def test_update_aborts_if_cluster_not_found(self, mock_dict_clusters):
+        creator = self._creator([{"workerInstances": []}])
+        mock_dict_clusters.return_value = {}
+        self.assertEqual(1, update.update(creator, startup.LOG))
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_aborts_if_existing_munge_key_cannot_be_read(self, mock_ssh_info, mock_read_remote_file,
+                                                                 mock_prepare, mock_defaults, mock_upload,
+                                                                 mock_terminate_server, mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = None
+        provider.get_server.return_value = {"private_v4": "10.0.0.1", "volumes": []}
+        configuration = {"workerInstances": [{"type": "t", "image": "i", "count": 4, "onDemand": False}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"}, "workers": []}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(1, update.update(creator, startup.LOG))
+        # must not proceed to (re-)generate a fresh, mismatched munge key and deploy it
+        mock_upload.assert_not_called()
+
+    @patch("bibigrid.core.actions.update.dict_clusters")
+    @patch("bibigrid.core.actions.update.terminate_server")
+    @patch.object(create.Create, "upload_data")
+    @patch.object(create.Create, "start_worker")
+    @patch.object(create.Create, "create_defaults")
+    @patch.object(create.Create, "prepare_configurations")
+    @patch("bibigrid.core.actions.update.ssh_handler.read_remote_file")
+    @patch("bibigrid.core.actions.update.cluster_ssh_handler.get_ssh_connection_info")
+    def test_update_failure_rolls_back_only_workers_created_this_run(self, mock_ssh_info, mock_read_remote_file,
+                                                                      mock_prepare, mock_defaults, mock_start_worker,
+                                                                      mock_upload, mock_terminate_server,
+                                                                      mock_dict_clusters):
+        provider = MagicMock()
+        mock_ssh_info.return_value = ("1.2.3.4", "ubuntu", "/tmp/key")
+        mock_read_remote_file.return_value = "existing-munge-key"
+        new_worker_server = {"name": "bibigrid-worker-abc123-3"}
+        provider.get_server.side_effect = lambda name: (
+            {"private_v4": "10.0.0.1", "volumes": []} if name == "bibigrid-master-abc123" else new_worker_server)
+        mock_upload.side_effect = ExecutionException("upload failed")
+        configuration = {"workerInstances": [{"type": "t", "image": "i", "count": 4, "onDemand": False}]}
+        creator = self._creator([configuration], providers=[provider])
+        cluster = {"master": {"name": "bibigrid-master-abc123"},
+                  "workers": [{"name": f"bibigrid-worker-abc123-{i}"} for i in range(3)]}
+        mock_dict_clusters.return_value = {"abc123": cluster}
+        self.assertEqual(1, update.update(creator, startup.LOG))
+        mock_start_worker.assert_called_once()
+        # only the worker update() created this run is cleaned up; the rest of the cluster is left alone
+        mock_terminate_server.assert_called_once_with(provider, new_worker_server, startup.LOG)


### PR DESCRIPTION
Adresses #718 

This PR allows to increase the number of worker nodes of an already existing cluster.

In order to increate worker count, change the number of workers in the config and reapply the config using the `-cid` CLI argument of an existing cluster.

Currently, *only* increasing worker node count is supported, other attributes cant be updated yet.
That would probably require a more sophisticated approach.

@XaverStiensmeier Would love to have some feedback from your side

I did test this by increasing the worker count of a running cluster.
I ended up with an additional, functional node in the same partition.