### PR TITLE
Set permissions for mounted disks

### DIFF
--- a/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-automount.yaml
+++ b/bibigrid/resources/playbook/roles/bibigrid/tasks/020-disk-automount.yaml
@@ -34,3 +34,11 @@
         src: "{{ item.device }}"
         state: mounted
         fstype: "{{ bibigrid_filesystem_type.stdout }}"
+
+    - name: Set permissions on mounted disks
+      file:
+        path: "{{ item.mountPoint }}"
+        state: directory
+        owner: ubuntu
+        group: "{{ ansible_distribution | lower }}"
+        mode: "0755"


### PR DESCRIPTION
Currently after the mount the permissions are still set to root.

The permissions needs to be set after the mount on the mounted data.